### PR TITLE
feat(image): make responsive

### DIFF
--- a/src/components/image/image.css
+++ b/src/components/image/image.css
@@ -1,0 +1,5 @@
+.rustic-image-responsive {
+  object-fit: contain;
+  width: 100%;
+  height: 100%;
+}

--- a/src/components/image/image.cy.tsx
+++ b/src/components/image/image.cy.tsx
@@ -16,12 +16,17 @@ describe('Image', () => {
     cy.get('img').should('have.attr', 'alt', 'An image is displayed')
   })
 
-  it('should set the width and height attributes to 200 if no width or height prop is provided', () => {
-    cy.mount(<Image {...defaultProps} />)
+  it('renders responsively if no width or height props are provided', () => {
+    const divWidth = 200
 
-    cy.get('img')
-      .should('have.attr', 'width', '200')
-      .should('have.attr', 'height', '200')
+    cy.mount(
+      <div style={{ width: `${divWidth}px` }}>
+        <Image {...defaultProps} />
+      </div>
+    )
+
+    cy.get('img').should('have.class', 'rustic-image-responsive')
+    cy.get('img').invoke('width').should('equal', divWidth)
   })
 
   it('renders image with provided props', () => {

--- a/src/components/image/image.stories.tsx
+++ b/src/components/image/image.stories.tsx
@@ -1,3 +1,6 @@
+import type { StoryFn } from '@storybook/react'
+import React from 'react'
+
 import Image from './image'
 
 export default {
@@ -21,7 +24,22 @@ export const Default = {
   },
 }
 
-export const Customized = {
+export const InsideSmallerParentContainer = {
+  args: {
+    url: 'https://assets-global.website-files.com/629d4351d174c60f32a4141a/647bfa926280c5b1cbccd03b_dragonscale_full_colour_rgb_icon_logo-p-500.png',
+  },
+  decorators: [
+    (Story: StoryFn) => {
+      return (
+        <div style={{ width: '200px' }}>
+          <Story />
+        </div>
+      )
+    },
+  ],
+}
+
+export const CustomizedWidthAndHeight = {
   args: {
     url: 'https://assets-global.website-files.com/629d4351d174c60f32a4141a/647bfa926280c5b1cbccd03b_dragonscale_full_colour_rgb_icon_logo-p-500.png',
     width: '100px',

--- a/src/components/image/image.tsx
+++ b/src/components/image/image.tsx
@@ -1,3 +1,5 @@
+import './image.css'
+
 import CircularProgress from '@mui/material/CircularProgress'
 import Typography from '@mui/material/Typography'
 import { useState } from 'react'
@@ -6,7 +8,7 @@ import React from 'react'
 export interface ImageProps {
   /** Path to the image source. */
   url: string
-  /** Width rendered in pixels. */
+  /** Width rendered in pixels. If neither width nor height are provided, the image will be set to be contained in the parent container. */
   width?: number
   /** Height rendered in pixels. */
   height?: number
@@ -27,14 +29,32 @@ export default function Image(props: ImageProps) {
     return <Typography variant="body2">{errorMessage}</Typography>
   }
 
+  let stylingAttributes = {}
+
+  if (props.width) {
+    stylingAttributes = {
+      width: props.width,
+    }
+  }
+  if (props.height) {
+    stylingAttributes = {
+      ...stylingAttributes,
+      height: props.height,
+    }
+  }
+  if (!props.width && !props.height) {
+    stylingAttributes = {
+      className: 'rustic-image-responsive',
+    }
+  }
+
   return (
     <>
       {isLoading && <CircularProgress data-cy="spinner" />}
       <img
+        {...stylingAttributes}
         src={props.url}
         alt={props.alt}
-        width={props.width}
-        height={props.height}
         onError={handleImageError}
         onLoad={() => {
           setIsLoading(false)
@@ -46,6 +66,4 @@ export default function Image(props: ImageProps) {
 
 Image.defaultProps = {
   alt: 'An image is displayed',
-  width: 200,
-  height: 200,
 }


### PR DESCRIPTION
## Changes
- Remove default props for `width` and `height`.
- Make it so that if neither `width` nor `height` props are provided, the image takes up the full width of the parent container.

## Screenshots

### Storybook
#### Before
<img width="523" alt="Screenshot 2024-03-06 at 10 26 59 AM" src="https://github.com/rustic-ai/ui-components/assets/111031789/b0548ba7-6643-4d7f-9ee5-2f6c52b13f65">

#### After
<img width="523" alt="Screenshot 2024-03-06 at 10 26 42 AM" src="https://github.com/rustic-ai/ui-components/assets/111031789/c7519b98-80a1-43c6-b023-ca028e963d82">

### Cypress Tests
<img width="333" alt="Screenshot 2024-03-06 at 10 16 03 AM" src="https://github.com/rustic-ai/ui-components/assets/111031789/d5bcb20e-743b-4f5b-8689-cc027cbaf6e9">
