### PR TITLE
docs: display functions properly in storybook, add copy example

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -42,6 +42,7 @@ const preview = {
     },
     controls: { expanded: true },
     docs: {
+      source: { type: 'code' },
       page: () => (
         <>
           <Title />

--- a/src/components/messageCanvas/messageCanvas.stories.tsx
+++ b/src/components/messageCanvas/messageCanvas.stories.tsx
@@ -2,6 +2,9 @@ import React from 'react'
 
 import Text from '../text/text'
 import MessageCanvas from './messageCanvas'
+import { ElementRenderer, MessageSpace, type ThreadableMessage } from '..'
+import IconButton from '@mui/material/IconButton'
+import FileCopyIcon from '@mui/icons-material/FileCopy'
 
 export default {
   title: 'Rustic UI/Message Canvas/Message Canvas',
@@ -32,7 +35,33 @@ const message = {
 
 export const Default = {
   args: {
-    children: <Text text={message.data.text} />,
+    children: (
+      <ElementRenderer message={message} supportedElements={{ text: Text }} />
+    ),
     message,
+  },
+}
+
+export const WithCopyFunction = {
+  args: {
+    children: (
+      <ElementRenderer message={message} supportedElements={{ text: Text }} />
+    ),
+    message,
+    messageInteractions: (message: ThreadableMessage) => {
+      return (
+        <IconButton
+          color="inherit"
+          aria-label="copy to clipboard"
+          onClick={() => {
+            if (message.data.text) {
+              navigator.clipboard.writeText(message.data.text)
+            }
+          }}
+        >
+          <FileCopyIcon />
+        </IconButton>
+      )
+    },
   },
 }


### PR DESCRIPTION
## Change
- Display functions properly in storybook
- Use ElementRenderer in MessageCanvas's stories
- Add copy example for MessageCanvas

## Screenshots
### Before
![Screenshot 2024-03-09 at 10 47 38 PM](https://github.com/rustic-ai/ui-components/assets/103023797/460e21d2-551d-47d3-9a99-ac4725c33b20)

### After
![Screenshot 2024-03-09 at 10 42 02 PM](https://github.com/rustic-ai/ui-components/assets/103023797/e293e75a-150b-456c-960a-e2ea0ab0741c)
