### PR TITLE
feat(openLayersMap): make responsive

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "codemirror": "6.0.1",
         "dompurify": "3.0.6",
         "marked": "10.0.0",
-        "ol": "8.2.0",
+        "ol": "9.0.0",
         "pluralize": "8.0.0",
         "react": "18.2.0",
         "react-dom": "18.2.0",
@@ -16599,9 +16599,9 @@
       "dev": true
     },
     "node_modules/ol": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/ol/-/ol-8.2.0.tgz",
-      "integrity": "sha512-/m1ddd7Jsp4Kbg+l7+ozR5aKHAZNQOBAoNZ5pM9Jvh4Etkf0WGkXr9qXd7PnhmwiC1Hnc2Toz9XjCzBBvexfXw==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/ol/-/ol-9.0.0.tgz",
+      "integrity": "sha512-+nYHZYbHrRUTDJ8ryxXPdDoAiaT6Zea02cocmGqsJXs4Oac1fYC9EbTIU2Y7803QcmG3u2MR88RxbksBvK+ZfQ==",
       "dependencies": {
         "color-rgba": "^3.0.0",
         "color-space": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "codemirror": "6.0.1",
     "dompurify": "3.0.6",
     "marked": "10.0.0",
-    "ol": "8.2.0",
+    "ol": "9.0.0",
     "pluralize": "8.0.0",
     "react": "18.2.0",
     "react-dom": "18.2.0",

--- a/src/components/map/openLayersMap.css
+++ b/src/components/map/openLayersMap.css
@@ -1,0 +1,8 @@
+.rustic-open-layers-map-canvas {
+  height: 200px;
+  width: 100%;
+}
+
+.rustic-open-layers-map-marker {
+  font-size: 40px;
+}

--- a/src/components/map/openLayersMap.cy.tsx
+++ b/src/components/map/openLayersMap.cy.tsx
@@ -6,15 +6,24 @@ describe('Map', () => {
   })
 
   it('renders the map canvas', () => {
-    cy.get('.ol-layer canvas').should('be.visible')
+    cy.get('[data-cy=map-canvas] .ol-layer canvas').should('be.visible')
+
+    cy.get('[data-cy="map-canvas"]').should(
+      'have.class',
+      'rustic-open-layers-map-canvas'
+    )
   })
 
   it('shows the marker', () => {
-    cy.get('svg').should('be.visible').should('have.css', 'font-size')
+    cy.get('[data-cy=marker-container] svg')
+      .should('be.visible')
+      .should('have.class', 'rustic-open-layers-map-marker')
   })
 
   it('shows an error if the coordinates are invalid', () => {
     cy.mount(<OpenLayersMap longitude={-181} latitude={49.2856} />)
     cy.contains('Invalid coordinates').should('be.visible')
+    cy.get('[data-cy=marker-container]').should('not.exist')
+    cy.get('[data-cy=map-canvas]').should('not.exist')
   })
 })

--- a/src/components/map/openLayersMap.stories.tsx
+++ b/src/components/map/openLayersMap.stories.tsx
@@ -7,11 +7,10 @@ const meta = {
   component: OpenLayersMap,
   tags: ['autodocs'],
   parameters: {
-    layout: 'centered',
     docs: {
       description: {
         component:
-          'The `OpenLayersMap` component supports OpenStreetMap tiles and offers customization options for width, height, and marker size. Users can easily zoom in and zoom out to navigate the map effectively. The `OpenLayersMap` component uses the [OpenLayers](https://openlayers.org/en/latest/apidoc/module-ol_Map-Map.html) map library.',
+          'The `OpenLayersMap` component supports OpenStreetMap tiles and offers customization options for width, height, and marker size. Users can easily zoom in and zoom out to navigate the map effectively. The `OpenLayersMap` component uses the [OpenLayers](https://openlayers.org/en/latest/apidoc/module-ol_Map-Map.html) map library.\n\nHeight and width are configured through the class `rustic-open-layers-map-canvas`.\n\nNote: If you are not seeing the component or come across the error "An error occurred while loading the map", ensure that `@import \'@rustic-ai/ui-components/dist/index.css\';` is at the top of your `index.css` file.',
       },
     },
   },
@@ -26,13 +25,11 @@ export const Default = {
   },
 }
 
-export const Customized = {
+export const CustomizedZoom = {
   args: {
     longitude: -123.1115,
     latitude: 49.2856,
     zoom: 15,
-    width: 500,
-    height: 300,
   },
 }
 

--- a/src/components/map/openLayersMap.tsx
+++ b/src/components/map/openLayersMap.tsx
@@ -1,4 +1,5 @@
 import 'ol/ol.css'
+import './openLayersMap.css'
 
 import PlaceIcon from '@mui/icons-material/Place'
 import Alert from '@mui/material/Alert'
@@ -19,12 +20,6 @@ export interface OpenLayersMapProps {
   latitude: number
   /** Zoom level. It is recommended that this unit stays below 20 for useful results. */
   zoom?: number
-  /** Width rendered in pixels. */
-  width?: number
-  /** Height rendered in pixels. */
-  height?: number
-  /** Size of the location marker rendered in rems. */
-  markerSize?: number
 }
 
 export default function OpenLayersMap(props: OpenLayersMapProps) {
@@ -79,30 +74,28 @@ export default function OpenLayersMap(props: OpenLayersMapProps) {
         newMap.removeOverlay(markerOverlay)
       }
     }
-  }, [props.longitude, props.latitude, props.zoom])
+  }, [])
 
   return (
-    <Box data-cy="map">
-      <Box>
-        {errorMessage && <Alert severity="error">{errorMessage}</Alert>}
-      </Box>
-      <Box ref={markerElement}>
-        <PlaceIcon sx={{ fontSize: props.markerSize }} />
-      </Box>
-      <div
-        ref={mapTargetElement}
-        style={{
-          width: `${props.width}px`,
-          height: `${props.height}px`,
-        }}
-      ></div>
-    </Box>
+    <>
+      {errorMessage.length > 0 ? (
+        <Alert severity="error">{errorMessage}</Alert>
+      ) : (
+        <Box>
+          <Box data-cy="marker-container" ref={markerElement}>
+            <PlaceIcon className="rustic-open-layers-map-marker" />
+          </Box>
+          <div
+            ref={mapTargetElement}
+            data-cy="map-canvas"
+            className="rustic-open-layers-map-canvas"
+          ></div>
+        </Box>
+      )}
+    </>
   )
 }
 
 OpenLayersMap.defaultProps = {
   zoom: 12,
-  width: 300,
-  height: 300,
-  markerSize: 50,
 }


### PR DESCRIPTION
## Changes
- make `OpenLayersMap` component responsive
- make `width`, `height`, and `markerSize` handled in css
- remove empty space and marker when error occurs
- update Open Layers version

## Screenshots
### Before
<img width="531" alt="Screenshot 2024-03-11 at 9 34 41 AM" src="https://github.com/rustic-ai/ui-components/assets/111031789/524a94fd-2be9-426e-83f5-51daefd15070">
<img width="531" alt="Screenshot 2024-03-11 at 9 34 51 AM" src="https://github.com/rustic-ai/ui-components/assets/111031789/042f95e5-b7f6-46cf-bcd7-6aaf93a1b8ae">

### After
<img width="532" alt="Screenshot 2024-03-11 at 12 11 47 PM" src="https://github.com/rustic-ai/ui-components/assets/111031789/819e02c8-8d0b-4751-b36a-dba597feac61">

### Cypress
<img width="696" alt="Screenshot 2024-03-11 at 12 15 04 PM" src="https://github.com/rustic-ai/ui-components/assets/111031789/7b3331fb-ade3-4b5a-84a5-f49fde888594">
