### PR TITLE
revert: "docs: display code properly, add copy example"

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -42,7 +42,6 @@ const preview = {
     },
     controls: { expanded: true },
     docs: {
-      source: { type: 'code' },
       page: () => (
         <>
           <Title />

--- a/src/components/messageCanvas/messageCanvas.stories.tsx
+++ b/src/components/messageCanvas/messageCanvas.stories.tsx
@@ -2,9 +2,6 @@ import React from 'react'
 
 import Text from '../text/text'
 import MessageCanvas from './messageCanvas'
-import { ElementRenderer, MessageSpace, type ThreadableMessage } from '..'
-import IconButton from '@mui/material/IconButton'
-import FileCopyIcon from '@mui/icons-material/FileCopy'
 
 export default {
   title: 'Rustic UI/Message Canvas/Message Canvas',
@@ -35,33 +32,7 @@ const message = {
 
 export const Default = {
   args: {
-    children: (
-      <ElementRenderer message={message} supportedElements={{ text: Text }} />
-    ),
+    children: <Text text={message.data.text} />,
     message,
-  },
-}
-
-export const WithCopyFunction = {
-  args: {
-    children: (
-      <ElementRenderer message={message} supportedElements={{ text: Text }} />
-    ),
-    message,
-    messageInteractions: (message: ThreadableMessage) => {
-      return (
-        <IconButton
-          color="inherit"
-          aria-label="copy to clipboard"
-          onClick={() => {
-            if (message.data.text) {
-              navigator.clipboard.writeText(message.data.text)
-            }
-          }}
-        >
-          <FileCopyIcon />
-        </IconButton>
-      )
-    },
   },
 }


### PR DESCRIPTION
This reverts commit bddaaee01b145b0ffd19aef8de9968e16055ddab.

This breaks existing functionality which makes it easy for users to copy code from the docs