### PR TITLE
fix: tests and imports

### DIFF
--- a/src/components/codeSnippet/codeSnippet.stories.tsx
+++ b/src/components/codeSnippet/codeSnippet.stories.tsx
@@ -1,6 +1,7 @@
 import type { StoryFn } from '@storybook/react'
-import CodeSnippet from './codeSnippet'
 import React from 'react'
+
+import CodeSnippet from './codeSnippet'
 export default {
   title: 'Rustic UI/CodeSnippet/CodeSnippet',
   component: CodeSnippet,

--- a/src/components/codeSnippet/codeSnippet.tsx
+++ b/src/components/codeSnippet/codeSnippet.tsx
@@ -1,12 +1,13 @@
 import './codeSnippet.css'
-import React, { useEffect, useState } from 'react'
-import { minimalSetup } from 'codemirror'
-import { EditorView, gutter } from '@codemirror/view'
-import { EditorState } from '@codemirror/state'
-import { Box } from '@mui/system'
-import { Typography } from '@mui/material'
-import { v4 as getUUID } from 'uuid'
+
 import { languages } from '@codemirror/language-data'
+import { EditorState } from '@codemirror/state'
+import { EditorView } from '@codemirror/view'
+import Typography from '@mui/material/Typography'
+import { Box } from '@mui/system'
+import { minimalSetup } from 'codemirror'
+import React, { useEffect } from 'react'
+import { v4 as getUUID } from 'uuid'
 
 export interface CodeSnippetProps {
   /** Code that will be displayed. */

--- a/src/components/messageCanvas/messageCanvas.cy.tsx
+++ b/src/components/messageCanvas/messageCanvas.cy.tsx
@@ -25,7 +25,7 @@ describe('MessageCanvas', () => {
     },
   }
 
-  it('renders children', () => {
+  it('renders the component', () => {
     cy.mount(
       <MessageCanvas message={testMessage}>
         <p>Hello World</p>
@@ -33,25 +33,7 @@ describe('MessageCanvas', () => {
     )
 
     cy.contains('Hello World').should('be.visible')
-  })
-
-  it('renders sender name if provided', () => {
-    cy.mount(
-      <MessageCanvas message={testMessage}>
-        <p>Hello World</p>
-      </MessageCanvas>
-    )
-
-    cy.get('[data-cy="sender"]').should('contain', 'senderId')
-  })
-
-  it('renders formatted timestamp', () => {
-    cy.mount(
-      <MessageCanvas message={testMessage}>
-        <p>Hello World</p>
-      </MessageCanvas>
-    )
-
+    cy.contains('senderId').should('be.visible')
     cy.contains('Jan 1 2020').should('be.visible')
   })
 

--- a/src/components/messageCanvas/messageCanvas.stories.tsx
+++ b/src/components/messageCanvas/messageCanvas.stories.tsx
@@ -1,10 +1,10 @@
+import FileCopyIcon from '@mui/icons-material/FileCopy'
+import IconButton from '@mui/material/IconButton'
 import React from 'react'
 
+import { ElementRenderer, type ThreadableMessage } from '..'
 import Text from '../text/text'
 import MessageCanvas from './messageCanvas'
-import { ElementRenderer, MessageSpace, type ThreadableMessage } from '..'
-import IconButton from '@mui/material/IconButton'
-import FileCopyIcon from '@mui/icons-material/FileCopy'
 
 export default {
   title: 'Rustic UI/Message Canvas/Message Canvas',

--- a/src/components/messageCanvas/messageCanvas.tsx
+++ b/src/components/messageCanvas/messageCanvas.tsx
@@ -21,9 +21,7 @@ export interface MessageCanvasProps {
 export default function MessageCanvas(props: MessageCanvasProps) {
   return (
     <Box id={props.message.id} className="rustic-message-canvas">
-      <Typography variant="body1" data-cy="sender">
-        {props.message.sender}:
-      </Typography>
+      <Typography variant="body1">{props.message.sender}:</Typography>
       <Card variant="outlined" className="rustic-message-canvas-card">
         {props.children}
       </Card>

--- a/src/components/messageSpace/messageSpace.stories.tsx
+++ b/src/components/messageSpace/messageSpace.stories.tsx
@@ -12,8 +12,8 @@ import {
   Text,
   YoutubeVideo,
 } from '..'
-import MessageSpace from './messageSpace'
 import CodeSnippet from '../codeSnippet/codeSnippet'
+import MessageSpace from './messageSpace'
 
 export default {
   title: 'Rustic UI/Message Space/Message Space',

--- a/src/components/video/youtubeVideo.cy.tsx
+++ b/src/components/video/youtubeVideo.cy.tsx
@@ -9,7 +9,6 @@ describe('YoutubeVideo', () => {
     cy.mount(<YoutubeVideo youtubeVideoId={youtubeVideoId} />)
     cy.get(youtubeVideoIframe)
       .should('be.visible')
-      .should('exist')
       .then(($iframe) => {
         // Wait for the iframe to load completely
         return new Cypress.Promise((resolve) => {
@@ -29,11 +28,7 @@ describe('YoutubeVideo', () => {
         cy.wrap($iframe)
           .its('0.contentDocument')
           .then(($iframeDoc) => {
-            cy.wrap($iframeDoc)
-              .find(playButton)
-              .should('be.visible')
-              .should('exist')
-              .click()
+            cy.wrap($iframeDoc).find(playButton).should('be.visible').click()
 
             // Check if the button with data-title-no-tooltip="Pause" exists
             cy.wrap($iframeDoc)
@@ -47,7 +42,6 @@ describe('YoutubeVideo', () => {
     cy.mount(<YoutubeVideo youtubeVideoId="invalidId" />)
     cy.get(youtubeVideoIframe)
       .should('be.visible')
-      .should('exist')
       .then(($iframe) => {
         // Wait for the iframe to load completely
         return new Cypress.Promise((resolve) => {
@@ -65,11 +59,7 @@ describe('YoutubeVideo', () => {
         cy.wrap($iframe)
           .its('0.contentDocument')
           .then(($iframeDoc) => {
-            cy.wrap($iframeDoc)
-              .find(playButton)
-              .should('be.visible')
-              .should('exist')
-              .click()
+            cy.wrap($iframeDoc).find(playButton).should('be.visible').click()
 
             cy.wrap($iframeDoc)
               .find('span')
@@ -100,11 +90,7 @@ describe('YoutubeVideo', () => {
         cy.wrap($iframe)
           .its('0.contentDocument')
           .then(($iframeDoc) => {
-            cy.wrap($iframeDoc)
-              .find(playButton)
-              .should('not.be.visible')
-              .should('exist')
-              .click()
+            cy.wrap($iframeDoc).find(playButton).should('be.visible').click()
 
             cy.wrap($iframeDoc)
               .find('span')


### PR DESCRIPTION
## Changes
- fix `youtubeVideo` test with incorrect assertion
- remove redundant assertions in `youtubeVideo` tests
- fix import statements for `codeSnippet`, `messageSpace`, and `messageCanvas` files
    - remove unused imports in `codeSnippet` and `messageCanvas` files
- condense tests for `messageCanvas`

## Cypress
<img width="696" alt="Screenshot 2024-03-11 at 4 44 53 PM" src="https://github.com/rustic-ai/ui-components/assets/111031789/1baf732d-a27d-4638-80dd-656d12edd9b6">