### PR TITLE
fix: add missing text primary color to theme

### DIFF
--- a/src/rusticTheme.ts
+++ b/src/rusticTheme.ts
@@ -105,6 +105,7 @@ let rusticLightTheme = createTheme({
     mode: 'light',
     divider: dividerColor,
     text: {
+      primary: '#1E0C04',
       secondary: '#4E443F',
       disabled: disabledColor,
     },


### PR DESCRIPTION
## Changes
- add missing text primary color to theme

## Design
<img width="291" alt="Screenshot 2024-03-13 at 12 37 16 PM" src="https://github.com/rustic-ai/ui-components/assets/111031789/d76e9fc0-84f7-4865-8d99-c851c92c95ab">
