### PR TITLE
docs(participantsContainer): remove bulletpoint from description

### DIFF
--- a/src/components/participantsContainer/participantsContainer.stories.tsx
+++ b/src/components/participantsContainer/participantsContainer.stories.tsx
@@ -24,7 +24,7 @@ export default {
     docs: {
       description: {
         component:
-          'The `ParticipantsContainer` component is responsible for displaying a list of participants within a dialog window. It organizes participants into separate lists based on their type (human or agent) and provides options to toggle between showing a subset of participants and displaying the full list. This component enhances the user experience by presenting participant information in a structured format and allowing users to view additional details as needed. \n - Note: The component does not include the button displayed to toggle between the two views. This button is typically implemented in the parent component that uses the `ParticipantsContainer` component.',
+          'The `ParticipantsContainer` component is responsible for displaying a list of participants within a dialog window. It organizes participants into separate lists based on their type (human or agent) and provides options to toggle between showing a subset of participants and displaying the full list. This component enhances the user experience by presenting participant information in a structured format and allowing users to view additional details as needed. \n\nNote: The component does not include the button displayed to toggle between the two views. This button is typically implemented in the parent component that uses the `ParticipantsContainer` component.',
       },
     },
   },


### PR DESCRIPTION
## Changes
- remove the bulletpoint from the "Note:" in the Storybook description to maintain consistency with other descriptions containing a "Note:"

## Screenshots
### Before
<img width="637" alt="Screenshot 2024-03-13 at 12 46 51 PM" src="https://github.com/rustic-ai/ui-components/assets/111031789/010b57d0-0039-4949-b257-f5790f7e5760">

### After
<img width="637" alt="Screenshot 2024-03-13 at 12 46 43 PM" src="https://github.com/rustic-ai/ui-components/assets/111031789/95494165-075e-4e5a-970c-3b8ef7814274">
