### PR TITLE
feat: add sender icon and update styling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -54,6 +54,7 @@
         "commitizen": "4.3.0",
         "css-loader": "6.10.0",
         "cypress": "13.6.5",
+        "cypress-real-events": "1.12.0",
         "cz-conventional-changelog": "3.3.0",
         "eslint": "8.56.0",
         "eslint-config-prettier": "9.1.0",
@@ -10014,6 +10015,15 @@
       },
       "engines": {
         "node": "^16.0.0 || ^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/cypress-real-events": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/cypress-real-events/-/cypress-real-events-1.12.0.tgz",
+      "integrity": "sha512-oiy+4kGKkzc2PT36k3GGQqkGxNiVypheWjMtfyi89iIk6bYmTzeqxapaLHS3pnhZOX1IEbTDUVxh8T4Nhs1tyQ==",
+      "dev": true,
+      "peerDependencies": {
+        "cypress": "^4.x || ^5.x || ^6.x || ^7.x || ^8.x || ^9.x || ^10.x || ^11.x || ^12.x || ^13.x"
       }
     },
     "node_modules/cypress/node_modules/execa": {

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "commitizen": "4.3.0",
     "css-loader": "6.10.0",
     "cypress": "13.6.5",
+    "cypress-real-events": "1.12.0",
     "cz-conventional-changelog": "3.3.0",
     "eslint": "8.56.0",
     "eslint-config-prettier": "9.1.0",

--- a/src/components/messageCanvas/messageCanvas.css
+++ b/src/components/messageCanvas/messageCanvas.css
@@ -1,3 +1,28 @@
-.rustic-message-canvas-card {
+.rustic-message-canvas {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.rustic-message-canvas .rustic-message-actions-container {
   padding: 16px;
+}
+
+.rustic-message-canvas .rustic-sender-info {
+  display: flex;
+  gap: 8px;
+}
+
+.rustic-message-canvas .rustic-message-footer {
+  opacity: 0;
+  display: flex;
+  align-items: center;
+}
+
+.rustic-message-canvas:hover .rustic-message-footer {
+  opacity: 1;
+}
+
+.rustic-message-canvas .rustic-timestamp {
+  margin-left: auto;
 }

--- a/src/components/messageCanvas/messageCanvas.cy.tsx
+++ b/src/components/messageCanvas/messageCanvas.cy.tsx
@@ -65,7 +65,7 @@ describe('MessageCanvas', () => {
     cy.get('[data-testid="AccountCircleIcon"]').should('be.visible')
   })
 
-  it('shows timestamp on hover on mobile', () => {
+  it('shows timestamp on touch on mobile', () => {
     cy.mount(
       <MessageCanvas message={testMessage}>
         <p>Hello World</p>

--- a/src/components/messageCanvas/messageCanvas.cy.tsx
+++ b/src/components/messageCanvas/messageCanvas.cy.tsx
@@ -1,3 +1,8 @@
+/* eslint-disable no-magic-numbers */
+import 'cypress-real-events'
+
+import AccountCircleIcon from '@mui/icons-material/AccountCircle'
+
 import MessageCanvas from './messageCanvas'
 
 describe('MessageCanvas', () => {
@@ -25,25 +30,86 @@ describe('MessageCanvas', () => {
     },
   }
 
-  it('renders the component', () => {
+  it('renders the component on mobile', () => {
     cy.mount(
-      <MessageCanvas message={testMessage}>
+      <MessageCanvas
+        message={testMessage}
+        getProfileComponent={() => {
+          return <AccountCircleIcon />
+        }}
+      >
         <p>Hello World</p>
       </MessageCanvas>
     )
 
     cy.contains('Hello World').should('be.visible')
     cy.contains('senderId').should('be.visible')
+    cy.get('[data-testid="AccountCircleIcon"]').should('be.visible')
+  })
+
+  it('renders the component on desktop', () => {
+    cy.viewport(1200, 700)
+    cy.mount(
+      <MessageCanvas
+        message={testMessage}
+        getProfileComponent={() => {
+          return <AccountCircleIcon />
+        }}
+      >
+        <p>Hello World</p>
+      </MessageCanvas>
+    )
+
+    cy.contains('Hello World').should('be.visible')
+    cy.contains('senderId').should('be.visible')
+    cy.get('[data-testid="AccountCircleIcon"]').should('be.visible')
+  })
+
+  it('shows timestamp on hover on mobile', () => {
+    cy.mount(
+      <MessageCanvas message={testMessage}>
+        <p>Hello World</p>
+      </MessageCanvas>
+    )
+    cy.contains('Jan 1 2020').should('not.be.visible')
+
+    cy.get('.rustic-message-canvas').realTouch()
+
     cy.contains('Jan 1 2020').should('be.visible')
   })
 
-  it('shows that it was last updated if an update is provided', () => {
+  it('shows timestamp on hover on desktop', () => {
+    cy.viewport(1200, 700)
+    cy.mount(
+      <MessageCanvas message={testMessage}>
+        <p>Hello World</p>
+      </MessageCanvas>
+    )
+    cy.contains('Jan 1 2020').should('not.be.visible')
+
+    cy.get('.rustic-message-canvas').realHover()
+
+    cy.contains('Jan 1 2020').should('be.visible')
+  })
+
+  it('shows that it was last updated on mobile if an update is provided', () => {
     cy.mount(
       <MessageCanvas message={testMessageUpdate}>
         <p>Hello World</p>
       </MessageCanvas>
     )
+    cy.get('.rustic-message-canvas').realTouch()
+    cy.contains('last updated').should('be.visible')
+  })
 
+  it('shows that it was last updated on desktop if an update is provided', () => {
+    cy.viewport(1200, 700)
+    cy.mount(
+      <MessageCanvas message={testMessageUpdate}>
+        <p>Hello World</p>
+      </MessageCanvas>
+    )
+    cy.get('.rustic-message-canvas').realHover()
     cy.contains('last updated').should('be.visible')
   })
 })

--- a/src/components/messageCanvas/messageCanvas.stories.tsx
+++ b/src/components/messageCanvas/messageCanvas.stories.tsx
@@ -1,5 +1,5 @@
-import FileCopyIcon from '@mui/icons-material/FileCopy'
-import IconButton from '@mui/material/IconButton'
+import AccountCircleIcon from '@mui/icons-material/AccountCircle'
+import SmartToyIcon from '@mui/icons-material/SmartToy'
 import React from 'react'
 
 import { ElementRenderer, type ThreadableMessage } from '..'
@@ -21,10 +21,10 @@ export default {
   },
 }
 
-const message = {
+const baseMessage = {
   id: '1',
   timestamp: '2020-01-02T00:00:00.000Z',
-  sender: 'Some Sender',
+
   conversationId: 'lkd9vc',
   topicId: 'default',
   format: 'text',
@@ -33,9 +33,115 @@ const message = {
   },
 }
 
-export const Default = {
+const messageFromAgent = {
+  ...baseMessage,
+  sender: 'Scheduling agent',
+}
+
+const messageFromHuman = {
+  ...baseMessage,
+  sender: 'Some sender',
+}
+
+export const WithProfileIcon = {
   args: {
-    children: <Text text={message.data.text} />,
-    message,
+    children: (
+      <ElementRenderer
+        message={messageFromHuman}
+        supportedElements={{ text: Text }}
+      />
+    ),
+    message: messageFromHuman,
+    getProfileComponent: (message: ThreadableMessage) => {
+      if (message.sender.includes('agent')) {
+        return <SmartToyIcon />
+      } else {
+        return <AccountCircleIcon />
+      }
+    },
+  },
+  parameters: {
+    docs: {
+      source: {
+        code: `<MessageCanvas
+        getProfileComponent={(message: ThreadableMessage) => {
+          if (message.sender.includes('agent')) return <SmartToyIcon />
+          else return <AccountCircleIcon />
+        }
+        message={{
+          conversationId: 'lkd9vc',
+          data: {
+            text: 'Lorem ipsum is placeholder text commonly used in the graphic, print, and publishing industries for previewing layouts and visual mockups.'
+          },
+          format: 'text',
+          id: '1',
+          sender: 'Scheduling agent',
+          timestamp: '2020-01-02T00:00:00.000Z',
+          topicId: 'default'
+        }}
+      >
+        <ElementRenderer
+          message={{
+            conversationId: 'lkd9vc',
+            data: {
+              text: 'Lorem ipsum is placeholder text commonly used in the graphic, print, and publishing industries for previewing layouts and visual mockups.'
+            },
+            format: 'text',
+            id: '1',
+            sender: 'Scheduling agent',
+            timestamp: '2020-01-02T00:00:00.000Z',
+            topicId: 'default'
+          }}
+          supportedElements={{ text: Text }}
+        />
+      </MessageCanvas>`,
+      },
+    },
+  },
+}
+
+export const NoIcon = {
+  args: {
+    children: (
+      <ElementRenderer
+        message={messageFromAgent}
+        supportedElements={{ text: Text }}
+      />
+    ),
+    message: messageFromAgent,
+  },
+  parameters: {
+    docs: {
+      source: {
+        code: `<MessageCanvas
+        message={{
+          conversationId: 'lkd9vc',
+          data: {
+            text: 'Lorem ipsum is placeholder text commonly used in the graphic, print, and publishing industries for previewing layouts and visual mockups.'
+          },
+          format: 'text',
+          id: '1',
+          sender: 'Scheduling agent',
+          timestamp: '2020-01-02T00:00:00.000Z',
+          topicId: 'default'
+        }}
+      >
+        <ElementRenderer
+          message={{
+            conversationId: 'lkd9vc',
+            data: {
+              text: 'Lorem ipsum is placeholder text commonly used in the graphic, print, and publishing industries for previewing layouts and visual mockups.'
+            },
+            format: 'text',
+            id: '1',
+            sender: 'Scheduling agent',
+            timestamp: '2020-01-02T00:00:00.000Z',
+            topicId: 'default'
+          }}
+          supportedElements={{ text: Text }}
+        />
+      </MessageCanvas>`,
+      },
+    },
   },
 }

--- a/src/components/messageCanvas/messageCanvas.tsx
+++ b/src/components/messageCanvas/messageCanvas.tsx
@@ -10,30 +10,50 @@ import Timestamp from '../timestamp/timestamp'
 import type { ThreadableMessage } from '../types'
 
 export interface MessageCanvasProps {
+  /** Profile icon to be shown before sender's name. */
+  getProfileComponent?: (message: ThreadableMessage) => ReactNode
   /** Message information to be displayed. Please see the `MessageSpace` docs for more information about the `ThreadableMessage` interface. */
   message: ThreadableMessage
   /** React component to be displayed in the message canvas. */
   children: ReactNode
-  /** Interactions with the message. For example, this could be a list of buttons for different actions (e.g. copy, delete, save, etc.) */
-  messageInteractions?: (message: ThreadableMessage) => ReactNode
+  /** Message actions. For example, this could be a list of buttons for different actions (e.g. copy, delete, save, etc.) */
+  getActionsComponent?: (message: ThreadableMessage) => ReactNode
 }
 
 export default function MessageCanvas(props: MessageCanvasProps) {
   return (
-    <Box id={props.message.id} className="rustic-message-canvas">
-      <Typography variant="body1">{props.message.sender}:</Typography>
-      <Card variant="outlined" className="rustic-message-canvas-card">
+    <Box
+      id={props.message.id}
+      className="rustic-message-canvas"
+      data-cy="message-canvas"
+    >
+      <Box className="rustic-sender-info">
+        {props.getProfileComponent && props.getProfileComponent(props.message)}
+        <Typography variant="body2" color="text.secondary" data-cy="sender">
+          {props.message.sender}:
+        </Typography>
+      </Box>
+      <Card variant="outlined" className="rustic-message-actions-container">
         {props.children}
       </Card>
-      {props.message.lastThreadMessage && (
-        <Typography variant="caption">last updated: </Typography>
-      )}
-      <Timestamp
-        timestamp={
-          props.message.lastThreadMessage?.timestamp || props.message.timestamp
-        }
-      />
-      {props.messageInteractions && props.messageInteractions(props.message)}
+      <Box className="rustic-message-footer">
+        {props.getActionsComponent && (
+          <Card variant="outlined">
+            {props.getActionsComponent(props.message)}
+          </Card>
+        )}
+        <Box className="rustic-timestamp">
+          {props.message.lastThreadMessage && (
+            <Typography variant="caption">last updated: </Typography>
+          )}
+          <Timestamp
+            timestamp={
+              props.message.lastThreadMessage?.timestamp ||
+              props.message.timestamp
+            }
+          />
+        </Box>
+      </Box>
     </Box>
   )
 }

--- a/src/components/messageSpace/messageSpace.stories.tsx
+++ b/src/components/messageSpace/messageSpace.stories.tsx
@@ -28,9 +28,9 @@ export default {
       description:
         'Messages to be displayed. Could have thread messages for the streaming components. `Interface MessageData { [key: string]: any }`\n\n<pre>```{\nInterface MessageProps {\n  id: string\n  timestamp: string\n  sender: string\n  conversationId: string\n  format: string\n  data: MessageData\n  inReplyTo?: string\n  threadId?: string\n  priority?: string;\n  taggedParticipants?: string[]\n  topicId?: string\n}\n\n```</pre><pre>```{\nInterface ThreadableMessage extends MessageProps {\n  lastThreadMessage?: MessageProps\n  threadMessagesData?: MessageData[]}```</pre>',
     },
-    messageInteractions: {
+    getActionsComponent: {
       description:
-        'Interactions with the message. For example, this could be a list of buttons for different actions (e.g. copy, delete, save, etc.)',
+        'Message actions. For example, this could be a list of buttons for different actions (e.g. copy, delete, save, etc.)',
     },
   },
   parameters: {

--- a/src/components/messageSpace/messageSpace.tsx
+++ b/src/components/messageSpace/messageSpace.tsx
@@ -11,7 +11,7 @@ import type { ComponentMap, ThreadableMessage } from '../types'
 export interface MessageSpaceProps {
   supportedElements: ComponentMap
   messages?: ThreadableMessage[]
-  messageInteractions?: (message: ThreadableMessage) => ReactNode
+  getActionsComponent?: (message: ThreadableMessage) => ReactNode
 }
 
 const MessageSpace = (props: MessageSpaceProps) => {
@@ -24,7 +24,7 @@ const MessageSpace = (props: MessageSpaceProps) => {
             <MessageCanvas
               key={message.id}
               message={message}
-              messageInteractions={props.messageInteractions}
+              getActionsComponent={props.getActionsComponent}
             >
               <ElementRenderer
                 message={message}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,7 +20,8 @@
     "isolatedModules": true,
     "noEmit": false,
     "jsx": "react-jsx",
-    "verbatimModuleSyntax": true
+    "verbatimModuleSyntax": true,
+    "types": ["cypress-real-events"]
   },
   "include": [
     "src",


### PR DESCRIPTION
## Changes
- Add sender icon
- Update the styling to match design (Time is shown on hover on desktop and on click on mobile)
- `cypress-real-events` is installed to check hover effect on cypress. 
## Screenshots
### Before
<img width="928" alt="Screenshot 2024-03-14 at 11 10 32 AM" src="https://github.com/rustic-ai/ui-components/assets/103023797/3757c4f1-2ed0-4b46-94e2-abf0e2caf18e">

### After
<img width="1045" alt="Screenshot 2024-03-14 at 11 11 40 AM" src="https://github.com/rustic-ai/ui-components/assets/103023797/44a3782d-bc96-458a-bf7a-f37a940fbed7">

## Videos
![Mar-14-2024 11-12-58](https://github.com/rustic-ai/ui-components/assets/103023797/e2696474-d51d-4c52-b5fe-b6404a80f08a)
![Mar-14-2024 11-13-39](https://github.com/rustic-ai/ui-components/assets/103023797/4fa16658-3c4f-4ec1-8f5b-0dd8c54f2889)
