### PR TITLE
docs: add figma link

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 The UI Components for Rustic AI is a comprehensive collection of reusable components designed specifically to empower developers in constructing interactive multimodal chat interfaces. With a focus on versatility and ease of integration, our library offers a wide range of components tailored to accommodate various chat functionalities. Whether you're building a chatbot, virtual assistant, or communication platform, Rustic UI Components provides the building blocks necessary to create engaging and dynamic user experiences.
 
+Additionally, our Rustic UI Component Library is available on Figma, enabling you to delve into the intricacies of our designs. Explore the [Figma file](https://www.figma.com/community/file/1340378790384732080) to gain insights into our innovative approach to UI design.
+
 To learn more about Rustic AI, visit our [website](https://rustic.ai).
 
 [![Commitizen friendly](https://img.shields.io/badge/commitizen-friendly-brightgreen.svg)](http://commitizen.github.io/cz-cli/)


### PR DESCRIPTION
## Changes
- Add the link for Figma Component Library to README

## Screenshots
### Before
<img width="877" alt="Screenshot 2024-03-15 at 4 52 00 PM" src="https://github.com/rustic-ai/ui-components/assets/103023797/324c0a76-4ca6-4882-b1cb-16e873fae20b">

### After

<img width="866" alt="Screenshot 2024-03-15 at 4 56 00 PM" src="https://github.com/rustic-ai/ui-components/assets/103023797/31f7c3ac-c26b-4290-8045-c6bd8bca3026">
