### PR TITLE
docs: update image to match design

### DIFF
--- a/src/components/messageSpace/messageSpace.stories.tsx
+++ b/src/components/messageSpace/messageSpace.stories.tsx
@@ -272,9 +272,10 @@ export const Default = {
         timestamp: '2024-01-02T00:11:00.000Z',
         format: 'image',
         data: {
-          width: '400px',
-          height: '400px',
-          url: 'https://assets-global.website-files.com/629d4351d174c60f32a4141a/647bfa926280c5b1cbccd03b_dragonscale_full_colour_rgb_icon_logo-p-500.png',
+          url: '/images/image-component-example.png',
+          alt: 'A curved facade covered in white latticework',
+          description:
+            'Lorem ipsum dolor sit amet consectetur. Aliquam vulputate sit non non tincidunt pellentesque varius euismod est. Lobortis feugiat euismod lorem viverra. Ipsum justo pellentesque.',
         },
       },
       {


### PR DESCRIPTION
## Changes
- Update image in MessageSpace's story to match Figma design

## Before

<img width="979" alt="Screenshot 2024-03-16 at 9 46 46 PM" src="https://github.com/rustic-ai/ui-components/assets/103023797/4c22fefc-cba7-463c-9c31-9b084e4265ea">



## After
<img width="980" alt="Screenshot 2024-03-16 at 9 47 06 PM" src="https://github.com/rustic-ai/ui-components/assets/103023797/a5ce243d-9fd9-4860-bb22-57a12e09ec6c">

