### PR TITLE
docs: add troubleshooting doc

### DIFF
--- a/docs/troubleshotting.stories.mdx
+++ b/docs/troubleshotting.stories.mdx
@@ -1,0 +1,30 @@
+import { Source, Meta } from '@storybook/addon-docs'
+
+<Meta title="Documentation/Troubleshooting" />
+
+# Troubleshooting
+
+Welcome to our Troubleshooting Documentation! Here, you'll find solutions to common issues encountered while using Rustic UI Components. This guide offers clear instructions to help you address errors, configuration problems, and compatibility issues swiftly. Our goal is to ensure a smooth experience with our components. If you encounter challenges beyond this guide, reach out to our support team for assistance. Let's troubleshoot together!
+
+**Q: Using the `CodeSnippet` component in my project gives me the error below. What should I do?**
+
+```
+Uncaught (in promise) Error: Unrecognized extension value in extension set ([object Object]).
+This sometimes happens because multiple instances of @codemirror/state are loaded, breaking instanceof checks.
+```
+
+A: If you are using webpack, follow these steps to resolve it:
+
+1.  Update `webpack.config.js` with the code below
+
+```
+resolve: {
+    alias: {
+      '@codemirror': path.resolve(__dirname, 'node_modules/@codemirror/'),
+    }
+  },
+```
+
+Make sure to add `const path = require('path')` at the top of the file if it's not already there.
+
+2.  You might need to remove the node_modules directory and package-lock.json file from your project directory and reinstall the dependencies.

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.4",
       "license": "MIT",
       "dependencies": {
+        "@codemirror/language": "6.10.1",
         "@codemirror/language-data": "6.4.1",
         "@codemirror/state": "6.4.1",
         "@codemirror/theme-one-dark": "6.1.2",
@@ -80,6 +81,7 @@
         "webpack-node-externals": "3.0.0"
       },
       "peerDependencies": {
+        "@codemirror/language": "6.10.1",
         "@codemirror/language-data": "6.4.1",
         "@codemirror/state": "6.4.1",
         "@codemirror/theme-one-dark": "6.1.2",

--- a/src/components/codeSnippet/codeSnippet.stories.tsx
+++ b/src/components/codeSnippet/codeSnippet.stories.tsx
@@ -12,7 +12,8 @@ export default {
       description: {
         component: `The CodeSnippet component, powered by [CodeMirror](https://codemirror.net/), enables the display of code blocks with syntax highlighting for various programming languages. 
         For further customization of the component's theme, refer to the [styling guide](https://codemirror.net/examples/styling/) provided by the CodeMirror library.
-        \nNote: CodeMirror libraries are not bundled, so they must be included in the application's build process.`,
+        \nNote: CodeMirror libraries are not bundled, so they must be included in the application's build process. Please install the following codemirror dependencies if you want to use CodeSnippet component in your project:
+        \n<pre><code>npm i @codemirror/language @codemirror/language-data @codemirror/state @codemirror/theme-one-dark @codemirror/view </code></pre>`,
       },
     },
   },


### PR DESCRIPTION
## Changes
- Add troubleshooting doc
- Add missing @codemirror/language to lock file (generated by npm i)

I'm thinking we could group issues later after we have more questions/answers. 

## Screenshot

<img width="1048" alt="Screenshot 2024-03-18 at 4 47 25 PM" src="https://github.com/rustic-ai/ui-components/assets/103023797/9d098695-4b67-49c5-ad84-0e6466b5e4ec">

<img width="990" alt="Screenshot 2024-03-18 at 4 47 56 PM" src="https://github.com/rustic-ai/ui-components/assets/103023797/51e248bc-e936-4a02-bb20-e5991965ded7">
