### PR TITLE
feat: add tooltip customization to theme file

### DIFF
--- a/src/components/tooltip/tooltip.stories.tsx
+++ b/src/components/tooltip/tooltip.stories.tsx
@@ -1,0 +1,115 @@
+import NotificationsIcon from '@mui/icons-material/Notifications'
+import IconButton from '@mui/material/IconButton'
+import Tooltip from '@mui/material/Tooltip'
+import React from 'react'
+
+export default {
+  title: 'Rustic UI/Tooltip/Tooltip',
+  component: Tooltip,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'centered',
+    docs: {
+      description: {
+        component:
+          "The Tooltip component offers a concise way to provide additional context or hints when users interact with elements in a UI. The library only customizes styling for MUI's tooltip to be inline with rusticTheme. For more information, please refer to the [MUI documentation](https://mui.com/material-ui/react-tooltip/).",
+      },
+    },
+  },
+}
+
+export const Default = {
+  args: {
+    title: 'Notifications',
+    children: (
+      <IconButton>
+        <NotificationsIcon />
+      </IconButton>
+    ),
+  },
+  parameters: {
+    docs: {
+      source: {
+        code: `<Tooltip title="Notifications">
+  <IconButton>
+    <NotificationsIcon />
+  </IconButton>
+</Tooltip>`,
+      },
+    },
+  },
+}
+
+export const ShowAtTop = {
+  args: {
+    title: 'Notifications',
+    children: (
+      <IconButton>
+        <NotificationsIcon />
+      </IconButton>
+    ),
+    placement: 'top',
+  },
+  parameters: {
+    docs: {
+      source: {
+        code: `<Tooltip title="Notifications" placement='top'>
+  <IconButton>
+    <NotificationsIcon />
+  </IconButton>
+</Tooltip>`,
+      },
+    },
+  },
+}
+
+export const CustomizeDistance = {
+  args: {
+    title: 'Notifications',
+    children: (
+      <IconButton>
+        <NotificationsIcon />
+      </IconButton>
+    ),
+    placement: 'top',
+    slotProps: {
+      popper: {
+        modifiers: [
+          {
+            name: 'offset',
+            options: {
+              // eslint-disable-next-line no-magic-numbers
+              offset: [0, -14],
+            },
+          },
+        ],
+      },
+    },
+  },
+  parameters: {
+    docs: {
+      source: {
+        code: `<Tooltip
+  placement="top"
+  slotProps={{
+    popper: {
+      modifiers: [
+        {
+          name: 'offset',
+          options: {
+            offset: [0, -14]
+          }
+        }
+      ]
+    }
+  }}
+  title="Notifications"
+ >
+  <IconButton>
+    <NotificationsIcon />
+  </IconButton>
+</Tooltip>`,
+      },
+    },
+  },
+}

--- a/src/rusticTheme.ts
+++ b/src/rusticTheme.ts
@@ -146,6 +146,16 @@ let rusticLightTheme = createTheme({
       disabled: disabledColor,
     },
   },
+  components: {
+    MuiTooltip: {
+      styleOverrides: {
+        tooltip: {
+          backgroundColor: '#3D3834',
+          color: '#FFFFFF',
+        },
+      },
+    },
+  },
 })
 
 let rusticDarkTheme = createTheme({
@@ -191,6 +201,16 @@ let rusticDarkTheme = createTheme({
       focus: '#FDFDFD',
       disabledBackground: '#E5E5E5',
       disabled: '#C7C2C0',
+    },
+  },
+  components: {
+    MuiTooltip: {
+      styleOverrides: {
+        tooltip: {
+          backgroundColor: '#FFFCFB',
+          color: '#2F2F2F',
+        },
+      },
     },
   },
 })


### PR DESCRIPTION
## Changes
- Add tooltip component 
- Add its stories and tests

## Screenshots
![Screenshot 2024-03-20 at 9 40 03 AM](https://github.com/rustic-ai/ui-components/assets/103023797/ea169616-4247-422f-8026-34f4b9b1cf75)
![Screenshot 2024-03-20 at 9 40 11 AM](https://github.com/rustic-ai/ui-components/assets/103023797/f83f6fde-e446-40b6-918a-39ba91acfb7d)
![Screenshot 2024-03-20 at 9 41 31 AM](https://github.com/rustic-ai/ui-components/assets/103023797/a97b89cc-8320-4b50-816c-73ecabbe4271)


## Video
![Mar-21-2024 09-57-40](https://github.com/rustic-ai/ui-components/assets/103023797/d424e61f-75b2-46b9-8f52-238947116e01)

