### PR TITLE
fix: handle empty array in table component

### DIFF
--- a/src/components/table/table.cy.tsx
+++ b/src/components/table/table.cy.tsx
@@ -49,5 +49,12 @@ describe('Table', () => {
         cy.get('th').contains(header, { matchCase: false })
       })
     })
+
+    it(`shows 'No data available' if empty array is provided on ${viewport} screen`, () => {
+      cy.viewport(viewport)
+
+      cy.mount(<Table data={[]} />)
+      cy.get('p').contains('No data available')
+    })
   })
 })

--- a/src/components/table/table.stories.tsx
+++ b/src/components/table/table.stories.tsx
@@ -83,3 +83,9 @@ export const HasHeadersProps = {
     data: sampleData,
   },
 }
+
+export const NoData = {
+  args: {
+    data: [],
+  },
+}

--- a/src/components/table/table.tsx
+++ b/src/components/table/table.tsx
@@ -24,6 +24,10 @@ export type TableProps = {
 }
 
 export default function Table(props: TableProps) {
+  if (props.data.length === 0) {
+    return <Typography variant="body2">No data available</Typography>
+  }
+
   const dataKeys = Array.from(
     new Set(props.data.flatMap((rowData) => Object.keys(rowData)))
   )


### PR DESCRIPTION
## Changes
- Handle empty array in table component
- Add test and story

## Screenshots
### Before
<img width="166" alt="Screenshot 2024-03-22 at 9 11 04 AM" src="https://github.com/rustic-ai/ui-components/assets/103023797/5b65444d-ab64-40d9-8697-40c6723377ca">

### After
<img width="1057" alt="Screenshot 2024-03-22 at 9 09 52 AM" src="https://github.com/rustic-ai/ui-components/assets/103023797/1fe5fa6d-9358-4343-8e77-fb154f859032">
