### PR TITLE
fix: table shows incorrect data

### DIFF
--- a/src/components/table/table.cy.tsx
+++ b/src/components/table/table.cy.tsx
@@ -56,5 +56,32 @@ describe('Table', () => {
       cy.mount(<Table data={[]} />)
       cy.get('p').contains('No data available')
     })
+
+    it(`does not show data if its header is not in the headers props on ${viewport} screen`, () => {
+      cy.viewport(viewport)
+      const headers = ['col1', 'col2']
+      const testDataWithExtra = [...testData, { col1: 'ghl', col3: 'extra' }]
+      cy.mount(<Table headers={headers} data={testDataWithExtra} />)
+      cy.contains('extra').should('not.exist')
+    })
+
+    it(`can render rows based on headers on ${viewport} screen`, () => {
+      cy.viewport(viewport)
+      const headers = ['col2', 'col1']
+      cy.mount(<Table headers={headers} data={testData} />)
+      cy.get('th').each((th, index) => {
+        expect(th.text().trim().toLowerCase()).contains(headers[index])
+      })
+
+      cy.get('.rustic-table tbody tr').each((row) => {
+        cy.wrap(row)
+          .find('td')
+          .each((cell, index) => {
+            const header = headers[index]
+            const value = (testData as Record<string, any>)[row.index()][header]
+            expect(cell.text().trim()).to.equal(value.toString())
+          })
+      })
+    })
   })
 })

--- a/src/components/table/table.stories.tsx
+++ b/src/components/table/table.stories.tsx
@@ -59,6 +59,13 @@ export const Default = {
   },
 }
 
+export const ChangeOrderUsingHeader = {
+  args: {
+    data: sampleData,
+    headers: ['food', 'carbs', 'protein', 'fat', 'calories'],
+  },
+}
+
 export const HasTitleAndDescription = {
   args: {
     title: 'Nutrient Data Comparison Across Various Types of Milk',

--- a/src/components/table/table.tsx
+++ b/src/components/table/table.tsx
@@ -69,10 +69,10 @@ export default function Table(props: TableProps) {
             {props.data.map((rowData, index) => {
               return (
                 <TableRow key={`row-${index}`}>
-                  {dataKeys.map((dataKey, dataIndex) => {
+                  {headers.map((header, dataIndex) => {
                     return (
                       <TableCell key={`cell-${index}x${dataIndex}`}>
-                        {rowData[dataKey]}
+                        {rowData[header]}
                       </TableCell>
                     )
                   })}


### PR DESCRIPTION
Resolves #39, resolves #38

## Changes
- Use headers to map table rows if headers props is available.  The order of columns could be changed using headers props now
- Add related stories and tests

Note: This PR will temporarily break the functionality of adding custom labels for headers. Will address this in a follow-up PR

## Screenshots
### Before
Without headers props
<img width="606" alt="Screenshot 2024-03-22 at 10 34 00 AM" src="https://github.com/rustic-ai/ui-components/assets/103023797/e0cba08d-dafb-428c-8311-7637cba511ec">

With headers props
<img width="927" alt="Screenshot 2024-03-22 at 10 33 50 AM" src="https://github.com/rustic-ai/ui-components/assets/103023797/f83896ec-4024-4f2a-afaf-e868e602eb33">

### After 
Without headers props
<img width="608" alt="Screenshot 2024-03-22 at 10 28 23 AM" src="https://github.com/rustic-ai/ui-components/assets/103023797/af307c1f-af43-4258-b64f-c1e39dc85bbe">
With headers props
<img width="516" alt="Screenshot 2024-03-22 at 10 36 13 AM" src="https://github.com/rustic-ai/ui-components/assets/103023797/4b1b37ee-3274-4298-b99a-f8edca2e4083">
Change order
<img width="537" alt="Screenshot 2024-03-22 at 10 28 38 AM" src="https://github.com/rustic-ai/ui-components/assets/103023797/780ec869-0e8b-4e56-bc18-ae458ad00422">