### PR TITLE
docs(codeSnippet): update title and description for consistency

### DIFF
--- a/src/components/codeSnippet/codeSnippet.stories.tsx
+++ b/src/components/codeSnippet/codeSnippet.stories.tsx
@@ -3,14 +3,14 @@ import React from 'react'
 
 import CodeSnippet from './codeSnippet'
 export default {
-  title: 'Rustic UI/CodeSnippet/CodeSnippet',
+  title: 'Rustic UI/Code Snippet/Code Snippet',
   component: CodeSnippet,
   tags: ['autodocs'],
   parameters: {
     layout: 'centered',
     docs: {
       description: {
-        component: `The CodeSnippet component, powered by [CodeMirror](https://codemirror.net/), enables the display of code blocks with syntax highlighting for various programming languages. 
+        component: `The \`CodeSnippet\` component, powered by [CodeMirror](https://codemirror.net/), enables the display of code blocks with syntax highlighting for various programming languages. 
         For further customization of the component's theme, refer to the [styling guide](https://codemirror.net/examples/styling/) provided by the CodeMirror library.
         \nNote: CodeMirror libraries are not bundled, so they must be included in the application's build process. Please install the following codemirror dependencies if you want to use CodeSnippet component in your project:
         \n<pre><code>npm i @codemirror/language @codemirror/language-data @codemirror/state @codemirror/theme-one-dark @codemirror/view </code></pre>`,


### PR DESCRIPTION
## Changes
- add space between name
- turn "CodeSnippet" into `CodeSnippet` in description for consistency