### PR TITLE
docs(rechartsTimeSeries): update prop descriptions

### DIFF
--- a/src/components/chart/rechartsTimeSeries.stories.tsx
+++ b/src/components/chart/rechartsTimeSeries.stories.tsx
@@ -9,7 +9,11 @@ export default {
     timeSeries: {
       control: 'array',
       description:
-        'Data to be displayed in the time series chart. The first field is used as the x-axis field. We currently support formatting timestamps in seconds and milliseconds. Other data types will be displayed as given. \n<pre>```interface TimeSeriesData:{\n  timestamp: number\n  [key: string]: number\n}```</pre>',
+        'Data to be displayed in the time series chart. The first field is used as the x-axis field. We currently support formatting timestamps in seconds and milliseconds. Other data types will be displayed as given. \n<pre>```interface TimeSeriesData {\n  timestamp: number\n  [key: string]: number\n}```</pre>',
+    },
+    chartContainerMargin: {
+      description:
+        'Margin of chart container in pixel. For example, adding left margin could show larger numbers properly.\n<pre>```interface Margin {\n  top?: number\n  right?: number\n  bottom?: number\n  left?: number\n}```</pre>',
     },
   },
   parameters: {

--- a/src/components/chart/rechartsTimeSeries.tsx
+++ b/src/components/chart/rechartsTimeSeries.tsx
@@ -74,7 +74,7 @@ export interface RechartsTimeSeriesProps {
   width?: number
   /** Chart type toggle will be hidden if the value is true. */
   disableChartTypeToggle?: boolean
-  /** Define the default chart type: 'line', 'bar', or 'area'. */
+  /** Define the default chart type: `line`, `bar`, or `area`. */
   defaultChartType?: TimeSeriesType
   /** Pass a function to format y-axis label. Make sure to use tooltipFormatter and yAxisTickFormatter together so that the numbers are uniform. */
   yAxisTickFormatter?: (value: number) => string


### PR DESCRIPTION
## Changes
- show format of `Margin` interface in prop description for `chartContainerMargin`
- show `defaultChartOptions` as inline code in prop description

## Screenshots
### Before
<img width="820" alt="Screenshot 2024-03-24 at 10 14 50 AM" src="https://github.com/rustic-ai/ui-components/assets/111031789/cf2a377a-a133-4070-8d46-593d3be94265">
<img width="820" alt="Screenshot 2024-03-24 at 10 14 25 AM" src="https://github.com/rustic-ai/ui-components/assets/111031789/60abb4e3-4acd-4667-a2a8-b52e1ddc87f7">

### After
<img width="820" alt="Screenshot 2024-03-24 at 10 15 32 AM" src="https://github.com/rustic-ai/ui-components/assets/111031789/4557cc5b-fe4c-4e33-906b-123a0b4d9e81">
<img width="820" alt="Screenshot 2024-03-24 at 10 15 24 AM" src="https://github.com/rustic-ai/ui-components/assets/111031789/87a44d0a-852d-4ad4-8c03-5f824f7b5598">
