### PR TITLE
feat(textInput): move position of send button

### DIFF
--- a/src/components/textInput/textInput.css
+++ b/src/components/textInput/textInput.css
@@ -1,3 +1,8 @@
+.rustic-text-input-container {
+  display: flex;
+  gap: 8px;
+}
+
 .rustic-text-input {
   border-radius: 16px;
 }

--- a/src/components/textInput/textInput.tsx
+++ b/src/components/textInput/textInput.tsx
@@ -1,8 +1,8 @@
 import './textInput.css'
 
 import SendIcon from '@mui/icons-material/Send'
+import Box from '@mui/material/Box'
 import IconButton from '@mui/material/IconButton'
-import InputAdornment from '@mui/material/InputAdornment'
 import TextField from '@mui/material/TextField'
 import { useState } from 'react'
 import React from 'react'
@@ -61,36 +61,32 @@ export default function TextInput(props: TextInputProps) {
   }
 
   return (
-    <TextField
-      data-cy="text-input"
-      className="rustic-text-input"
-      variant="outlined"
-      value={messageText}
-      label={props.label}
-      maxRows={props.maxRows}
-      multiline={props.multiline}
-      fullWidth={props.fullWidth}
-      onKeyDown={handleKeyDown}
-      onChange={handleOnChange}
-      sx={{
-        backgroundColor: 'background.paper',
-      }}
-      InputProps={{
-        endAdornment: (
-          <InputAdornment position="end">
-            <IconButton
-              data-cy="send-button"
-              aria-label="send message"
-              onClick={handleSendMessage}
-              disabled={isEmptyMessage}
-              color="primary"
-            >
-              <SendIcon />
-            </IconButton>
-          </InputAdornment>
-        ),
-      }}
-    />
+    <Box className="rustic-text-input-container">
+      <TextField
+        data-cy="text-input"
+        className="rustic-text-input"
+        variant="outlined"
+        value={messageText}
+        label={props.label}
+        maxRows={props.maxRows}
+        multiline={props.multiline}
+        fullWidth={props.fullWidth}
+        onKeyDown={handleKeyDown}
+        onChange={handleOnChange}
+        sx={{
+          backgroundColor: 'background.paper',
+        }}
+      />
+      <IconButton
+        data-cy="send-button"
+        aria-label="send message"
+        onClick={handleSendMessage}
+        disabled={isEmptyMessage}
+        color="primary"
+      >
+        <SendIcon />
+      </IconButton>
+    </Box>
   )
 }
 


### PR DESCRIPTION
## Changes
- move the send button outside of the input to match the [Figma design](https://www.figma.com/file/dzsbmMmPLRR4EFVPZF7F8i/Rustic-UI---Component-Library?node-id=967%3A3737&mode=dev)

## Screenshots
### Design
<img width="664" alt="Screenshot 2024-03-25 at 5 06 43 PM" src="https://github.com/rustic-ai/ui-components/assets/111031789/77ab244e-29a4-4214-aeb7-cb35e8926284">

### Before
<img width="306" alt="Screenshot 2024-03-25 at 5 08 33 PM" src="https://github.com/rustic-ai/ui-components/assets/111031789/5c645236-db87-4c0a-a6ba-b539a7af15e6">

### After
<img width="306" alt="Screenshot 2024-03-25 at 5 08 10 PM" src="https://github.com/rustic-ai/ui-components/assets/111031789/5b34ae47-871b-4f41-9cac-2c6986ae7190">
