### PR TITLE
docs(textInput): update incorrect description for ws prop

### DIFF
--- a/src/components/textInput/textInput.stories.tsx
+++ b/src/components/textInput/textInput.stories.tsx
@@ -7,7 +7,7 @@ export default {
   argTypes: {
     ws: {
       description:
-        'WebSocket connection to send and receive messages to and from a backend. \n<pre>```interface WebSocketClients:{\n  send: (message: MessageProps) => void\n  close: () => void\n  reconnect: () => void\n}```</pre>',
+        'WebSocket connection to send and receive messages to and from a backend. \n<pre>```interface WebSocketClient {\n  send: (message: MessageProps) => void\n  close: () => void\n  reconnect: () => void\n}```</pre>',
     },
   },
   parameters: {


### PR DESCRIPTION
## Changes
- change `WebSocketClients` to `WebSocketClient` in ws prop description and remove incorrect use of colon

## Screenshots
### Before
<img width="686" alt="Screenshot 2024-03-25 at 5 14 56 PM" src="https://github.com/rustic-ai/ui-components/assets/111031789/3dbdd901-e369-442f-8509-272d16464b3d">

### After
<img width="686" alt="Screenshot 2024-03-25 at 5 14 43 PM" src="https://github.com/rustic-ai/ui-components/assets/111031789/ac0d0699-18e7-4476-8e6b-4c1858b693fe">
