### PR TITLE
feat: update component to match Figma design and update theme

### DIFF
--- a/src/components/textInput/textInput.css
+++ b/src/components/textInput/textInput.css
@@ -1,8 +1,9 @@
 .rustic-text-input-container {
   display: flex;
+  align-items: center;
   gap: 8px;
 }
 
-.rustic-text-input {
-  border-radius: 16px;
+.rustic-text-input-container .rustic-text-input fieldset[aria-hidden='true'] {
+  border-width: 1px;
 }

--- a/src/components/textInput/textInput.stories.tsx
+++ b/src/components/textInput/textInput.stories.tsx
@@ -25,7 +25,7 @@ export const Default = {
   args: {
     sender: 'You',
     conversationId: '1',
-    label: 'Type your message',
+    placeholder: 'Type your message',
   },
 }
 
@@ -40,5 +40,12 @@ export const CustomizedMaxRows = {
   args: {
     ...Default.args,
     maxRows: 2,
+  },
+}
+
+export const WithLabel = {
+  args: {
+    ...Default.args,
+    label: 'Custom Label',
   },
 }

--- a/src/components/textInput/textInput.tsx
+++ b/src/components/textInput/textInput.tsx
@@ -16,8 +16,10 @@ export interface TextInputProps {
   sender: string
   /** Id of the current conversation. */
   conversationId: string
-  /** Placeholder text to be displayed in the text input box. */
-  label: string
+  /** Label text to be displayed in the input, which will then move to the top when the input is focused on. If both label and placeholder are provided, the placeholder will only be visible once the input is focused on. */
+  label?: string
+  /** Placeholder text to be displayed in the input before user starts typing. */
+  placeholder?: string
   /** Boolean that dictates whether `TextInput` can expand to be multiline. */
   multiline?: boolean
   /** Maximum number of rows to be displayed. */
@@ -68,14 +70,14 @@ export default function TextInput(props: TextInputProps) {
         variant="outlined"
         value={messageText}
         label={props.label}
+        placeholder={props.placeholder}
         maxRows={props.maxRows}
         multiline={props.multiline}
         fullWidth={props.fullWidth}
         onKeyDown={handleKeyDown}
         onChange={handleOnChange}
-        sx={{
-          backgroundColor: 'background.paper',
-        }}
+        color="secondary"
+        size="small"
       />
       <IconButton
         data-cy="send-button"

--- a/src/rusticTheme.ts
+++ b/src/rusticTheme.ts
@@ -56,7 +56,7 @@ const baseTheme = createTheme({
     },
     body1: {
       fontStyle: 'normal',
-      fontWeight: 700,
+      fontWeight: 400,
       fontSize: '16px',
       letterSpacing: '0.15px',
     },


### PR DESCRIPTION
## Changes
- update styles to match [Figma design](https://www.figma.com/file/dzsbmMmPLRR4EFVPZF7F8i/Rustic-UI---Component-Library?type=design&node-id=967-3737&mode=design&t=qz9MesECgLOiR2t8-0)
- add `placeholder` prop
- make `label` prop optional
- update prop descriptions to distinguish between `label` and `placeholder`- the prop description of `label` used the word "placeholder" to describe this functionality
- update theme typography
    - change font weight of `body1` 

## Screenshots
### Design
#### Unfocused
<img width="664" alt="Screenshot 2024-03-25 at 5 06 43 PM" src="https://github.com/rustic-ai/ui-components/assets/111031789/9c9c6fe8-d222-4e6b-9135-3d9c2864df7d">

#### Focused
<img width="665" alt="Screenshot 2024-03-27 at 1 10 35 PM" src="https://github.com/rustic-ai/ui-components/assets/111031789/d0aa3b1a-726a-4330-8191-6b1714185d05">

### Before
#### Unfocused
![Screenshot 2024-03-26 at 3 52 05 PM](https://github.com/rustic-ai/ui-components/assets/111031789/5c146aff-266a-44de-b813-dc61b78a4b8a)

#### Focused
![Screenshot 2024-03-26 at 3 52 30 PM](https://github.com/rustic-ai/ui-components/assets/111031789/ef080b44-415c-449a-977d-44f8cef9d22f)

### After
#### Unfocused
![Screenshot 2024-03-26 at 3 42 55 PM](https://github.com/rustic-ai/ui-components/assets/111031789/7e634449-7f1a-4f41-8f26-f8897822a432)

#### Focused
![Screenshot 2024-03-26 at 3 43 02 PM](https://github.com/rustic-ai/ui-components/assets/111031789/b00798b2-1485-438b-b878-57135bca7182)

#### With Label Prop
<img width="1044" alt="Screenshot 2024-03-27 at 6 02 09 PM" src="https://github.com/rustic-ai/ui-components/assets/111031789/9a2ea3fb-6c46-4d9a-9a80-edccca4d01dd">
<img width="1044" alt="Screenshot 2024-03-27 at 6 02 16 PM" src="https://github.com/rustic-ai/ui-components/assets/111031789/fc9e00ae-f5ad-4c76-aa38-4effa9f220a7">

### Video
![Apr-02-2024 07-59-06](https://github.com/rustic-ai/ui-components/assets/111031789/a8033e27-6e4a-4eae-9b9f-3f95d041c710)
