### PR TITLE
fix: add missing theme colors

### DIFF
--- a/src/rusticTheme.ts
+++ b/src/rusticTheme.ts
@@ -2,9 +2,10 @@
 import type { Shadows } from '@mui/material/styles'
 import { createTheme, responsiveFontSizes } from '@mui/material/styles'
 
-const dividerColor = '#DDD0CA'
-const disabledColor = '#C7C2C0'
-const muiGeneralSetting = {
+const whiteColor = '#FFFFFF'
+const SecondaryMainColor = '#FF6928'
+const SecondaryDarkColor = '#E54500'
+const baseTheme = createTheme({
   shape: {
     borderRadius: 16,
   },
@@ -84,6 +85,24 @@ const muiGeneralSetting = {
       letterSpacing: '0.04px',
     },
   },
+  palette: {
+    common: {
+      black: '#000000',
+      white: whiteColor,
+    },
+    error: {
+      main: '#F82A43',
+    },
+    warning: {
+      main: '#FFB800',
+    },
+    info: {
+      main: '#0094FF',
+    },
+    success: {
+      main: '#35A700',
+    },
+  },
   shadows: [
     ...createTheme({}).shadows.map((shadow, i) => {
       if (i === 1) {
@@ -97,100 +116,81 @@ const muiGeneralSetting = {
       }
     }),
   ] as Shadows,
-}
+})
 
+const lightModeDividerColor = '#DDD0CA'
+const lightModeDisabledColor = '#C7C2C0'
+const lightModePrimaryMainColor = '#3D3834'
+const lightModeBackgroundDefaultColor = '#F4F0EF'
 let rusticLightTheme = createTheme({
-  ...muiGeneralSetting,
+  ...baseTheme,
   palette: {
     mode: 'light',
-    divider: dividerColor,
+    divider: lightModeDividerColor,
     text: {
       primary: '#1E0C04',
       secondary: '#4E443F',
-      disabled: disabledColor,
+      disabled: lightModeDisabledColor,
     },
     primary: {
-      main: '#3D3834',
-      contrastText: '#FFFFFF',
+      main: lightModePrimaryMainColor,
+      contrastText: whiteColor,
       dark: '#2D2825',
-      light: dividerColor,
+      light: lightModeDividerColor,
     },
     secondary: {
-      main: '#FF6928',
+      main: SecondaryMainColor,
       light: '#FFDBCC',
-      dark: '#E54500',
-    },
-    error: {
-      main: '#F82A43',
-      dark: '#B51616',
-    },
-    warning: {
-      main: '#FFB800',
-    },
-    info: {
-      main: '#0094FF',
-    },
-    success: {
-      main: '#35A700',
+      dark: SecondaryDarkColor,
     },
     background: {
-      default: '#F4F0EF',
-      paper: '#FFFFFF',
+      default: lightModeBackgroundDefaultColor,
+      paper: whiteColor,
     },
     action: {
       active: '#5F5C5A',
       hover: '#F1ECEA',
-      selected: disabledColor,
+      selected: lightModeDisabledColor,
       disabledBackground: '#E5E5E5',
-      focus: '#F4F0EF',
-      disabled: disabledColor,
+      focus: lightModeBackgroundDefaultColor,
+      disabled: lightModeDisabledColor,
     },
   },
   components: {
     MuiTooltip: {
       styleOverrides: {
         tooltip: {
-          backgroundColor: '#3D3834',
-          color: '#FFFFFF',
+          backgroundColor: lightModePrimaryMainColor,
+          color: whiteColor,
         },
       },
     },
   },
 })
 
+const darkModePaperColor = '#2F2F2F'
+const darkModePrimraryMainColor = '#FFFCFB'
 let rusticDarkTheme = createTheme({
-  ...muiGeneralSetting,
+  ...baseTheme,
   palette: {
     mode: 'dark',
     primary: {
-      main: '#FFFCFB',
-      dark: '#E54500',
+      main: darkModePrimraryMainColor,
+      dark: SecondaryDarkColor,
       light: '#FFDBCC',
     },
     secondary: {
-      main: '#FF6928',
+      main: SecondaryMainColor,
       light: '#FFA983',
-      dark: '#E54500',
-    },
-    error: {
-      main: '#F82A43',
-    },
-    warning: {
-      main: '#FFB800',
-    },
-    info: {
-      main: '#0094FF',
-    },
-    success: {
-      main: '#35A700',
+      dark: SecondaryDarkColor,
     },
     background: {
       default: '#040404',
-      paper: '#2F2F2F',
+      paper: darkModePaperColor,
     },
     divider: '#D0C4BE',
     text: {
-      primary: '#FFFFFF',
+      primary: whiteColor,
       secondary: '#EBEBEB',
       disabled: '#C1C1C1',
     },
@@ -207,8 +207,8 @@ let rusticDarkTheme = createTheme({
     MuiTooltip: {
       styleOverrides: {
         tooltip: {
-          backgroundColor: '#FFFCFB',
-          color: '#2F2F2F',
+          backgroundColor: darkModePrimraryMainColor,
+          color: darkModePaperColor,
         },
       },
     },


### PR DESCRIPTION
## Changes
- Add common/black and white colors (Design system has been updated. Need common colors that won't changed when switching between light mode and dark mode. Will be used in the video component.)
- Create baseTheme first, then create light and dark theme
- Define some color variables for colors that appear more than once

##Screenshots (no changes)
### Before
<img width="300" alt="Screenshot 2024-04-01 at 10 42 04 AM" src="https://github.com/rustic-ai/ui-components/assets/103023797/b7ece4df-027b-46e9-99b7-f577abd93153">
<img width="978" alt="Screenshot 2024-04-01 at 10 40 52 AM" src="https://github.com/rustic-ai/ui-components/assets/103023797/68fbf1cf-0e66-4e6a-9c2b-b9f23f723b46">

### After
<img width="320" alt="Screenshot 2024-04-01 at 10 42 25 AM" src="https://github.com/rustic-ai/ui-components/assets/103023797/f6355cab-7fe7-4939-8909-175c43a83371">
<img width="971" alt="Screenshot 2024-04-01 at 10 41 26 AM" src="https://github.com/rustic-ai/ui-components/assets/103023797/eebac718-d7e4-4bb2-968f-7b6c09b102be">

