### PR TITLE
fix: add missing props to MessageSpace

### DIFF
--- a/src/components/messageSpace/messageSpace.css
+++ b/src/components/messageSpace/messageSpace.css
@@ -1,4 +1,4 @@
-.rustic-messages-space {
+.rustic-message-space {
   overflow-y: scroll;
   display: flex;
   flex-direction: column;

--- a/src/components/messageSpace/messageSpace.cy.tsx
+++ b/src/components/messageSpace/messageSpace.cy.tsx
@@ -1,3 +1,5 @@
+import AccountCircleIcon from '@mui/icons-material/AccountCircle'
+import SmartToyIcon from '@mui/icons-material/SmartToy'
 import { v4 as getUUID } from 'uuid'
 
 import { supportedViewports } from '../../../cypress/support/variables'
@@ -6,6 +8,7 @@ import {
   Image,
   MarkedMarkdown,
   MarkedStreamingMarkdown,
+  type MessageProps,
   OpenLayersMap,
   RechartsTimeSeries,
   StreamingText,
@@ -77,16 +80,28 @@ describe('MessageSpace Component', () => {
         <MessageSpace
           messages={messages}
           supportedElements={supportedElements}
+          getProfileComponent={(message: MessageProps) => {
+            if (message.sender.includes('Agent')) {
+              return <SmartToyIcon data-cy="agent-icon" />
+            } else {
+              return <AccountCircleIcon data-cy="human-icon" />
+            }
+          }}
         />
       )
       const messageSpace = '[data-cy=message-space]'
 
       cy.get(messageSpace).should('exist')
 
-      messages.forEach((message) => {
+      messages.forEach((message, index) => {
         cy.get(messageSpace)
           .should('contain', message.sender)
           .and('contain', message.data.text)
+        if (message.sender === 'Agent') {
+          cy.get('svg').eq(index).should('have.attr', 'data-cy', 'agent-icon')
+        } else {
+          cy.get('svg').eq(index).should('have.attr', 'data-cy', 'human-icon')
+        }
       })
     })
   })

--- a/src/components/messageSpace/messageSpace.stories.tsx
+++ b/src/components/messageSpace/messageSpace.stories.tsx
@@ -1,3 +1,6 @@
+import AccountCircleIcon from '@mui/icons-material/AccountCircle'
+import SmartToyIcon from '@mui/icons-material/SmartToy'
+import React from 'react'
 import { v4 as getUUID } from 'uuid'
 
 import {
@@ -5,6 +8,7 @@ import {
   Image,
   MarkedMarkdown,
   MarkedStreamingMarkdown,
+  type MessageProps,
   OpenLayersMap,
   RechartsTimeSeries,
   StreamingText,
@@ -22,7 +26,7 @@ export default {
   argTypes: {
     supportedElements: {
       description:
-        'An ComponentMap contains message formats as keys and their corresponding React components as values.`interface ComponentMap {[key: string]: React.ComponentType<any>}`',
+        'A component map contains message formats as keys and their corresponding React components as values.`interface ComponentMap {[key: string]: React.ComponentType<any>}`',
     },
     messages: {
       description:
@@ -32,13 +36,16 @@ export default {
       description:
         'Message actions. For example, this could be a list of buttons for different actions (e.g. copy, delete, save, etc.)',
     },
+    getProfileComponent: {
+      description: "Profile icon to be shown before the sender's name.",
+    },
   },
   parameters: {
     layout: 'centered',
     docs: {
       description: {
         component:
-          'The `MessageSpace` component uses `MessageCanvas` and `ElementRenderer` to render a list of messages. It serves as a container for individual message items, each encapsulated within a MessageCanvas for consistent styling and layout.',
+          'The `MessageSpace` component uses `MessageCanvas` and `ElementRenderer` to render a list of messages. It serves as a container for individual message items, each encapsulated within a `MessageCanvas` for consistent styling and layout.',
       },
     },
   },
@@ -325,6 +332,13 @@ export const Default = {
       table: Table,
       calendar: FCCalendar,
       codeSnippet: CodeSnippet,
+    },
+    getProfileComponent: (message: MessageProps) => {
+      if (message.sender.includes('Agent')) {
+        return <SmartToyIcon />
+      } else {
+        return <AccountCircleIcon />
+      }
     },
   },
 }

--- a/src/components/messageSpace/messageSpace.tsx
+++ b/src/components/messageSpace/messageSpace.tsx
@@ -6,17 +6,18 @@ import React from 'react'
 
 import ElementRenderer from '../elementRenderer/elementRenderer'
 import MessageCanvas from '../messageCanvas/messageCanvas'
-import type { ComponentMap, ThreadableMessage } from '../types'
+import type { ComponentMap, MessageProps, ThreadableMessage } from '../types'
 
 export interface MessageSpaceProps {
   supportedElements: ComponentMap
   messages?: ThreadableMessage[]
-  getActionsComponent?: (message: ThreadableMessage) => ReactNode
+  getActionsComponent?: (message: MessageProps) => ReactNode
+  getProfileComponent?: (message: MessageProps) => ReactNode
 }
 
 const MessageSpace = (props: MessageSpaceProps) => {
   return (
-    <Box data-cy="message-space" className="rustic-messages-space">
+    <Box data-cy="message-space" className="rustic-message-space">
       {props.messages &&
         props.messages.length > 0 &&
         props.messages.map((message) => {
@@ -25,6 +26,7 @@ const MessageSpace = (props: MessageSpaceProps) => {
               key={message.id}
               message={message}
               getActionsComponent={props.getActionsComponent}
+              getProfileComponent={props.getProfileComponent}
             >
               <ElementRenderer
                 message={message}


### PR DESCRIPTION
## Changes
- Add `getProfileComponent` props to `MessageSpace`. This props is used in `MessageCanvas`

## Screenshots
### Before
![Screenshot 2024-03-30 at 3 23 58 PM](https://github.com/rustic-ai/ui-components/assets/103023797/69256988-8298-4197-a753-dd6f8a9ec87a)

### After
![Screenshot 2024-03-30 at 3 23 17 PM](https://github.com/rustic-ai/ui-components/assets/103023797/d0e0a0ad-acb3-4ba7-9d2e-aae78bd07071)
