### PR TITLE
fix: menu background color and update theme

### DIFF
--- a/src/components/menu/popoverMenu.tsx
+++ b/src/components/menu/popoverMenu.tsx
@@ -130,6 +130,7 @@ export default function PopoverMenu(props: PopoverMenuProps) {
         sx={{
           '& .MuiPaper-root': {
             ...menuBorderStyles,
+            backgroundImage: 'none',
             // eslint-disable-next-line no-magic-numbers
             boxShadow: theme.shadows[2],
           },

--- a/src/rusticTheme.ts
+++ b/src/rusticTheme.ts
@@ -5,6 +5,13 @@ import { createTheme, responsiveFontSizes } from '@mui/material/styles'
 const whiteColor = '#FFFFFF'
 const SecondaryMainColor = '#FF6928'
 const SecondaryDarkColor = '#E54500'
+const actionActiveColor = '#5F5C5A'
+const actionFocusColor = '#FDFDFD'
+const actionDisabledBackgroundColor = '#E5E5E5'
+const actionDisabledColor = '#C7C2C0'
+const actionSelectedColor = '#D6D0D0'
+const dividerColor = '#D0C4BE'
+
 const baseTheme = createTheme({
   shape: {
     borderRadius: 16,
@@ -118,25 +125,22 @@ const baseTheme = createTheme({
   ] as Shadows,
 })
 
-const lightModeDividerColor = '#DDD0CA'
-const lightModeDisabledColor = '#C7C2C0'
 const lightModePrimaryMainColor = '#3D3834'
 const lightModeBackgroundDefaultColor = '#F4F0EF'
 let rusticLightTheme = createTheme({
   ...baseTheme,
   palette: {
     mode: 'light',
-    divider: lightModeDividerColor,
+    divider: dividerColor,
     text: {
       primary: '#1E0C04',
       secondary: '#4E443F',
-      disabled: lightModeDisabledColor,
+      disabled: '#B0ACAB',
     },
     primary: {
       main: lightModePrimaryMainColor,
-      contrastText: whiteColor,
       dark: '#2D2825',
-      light: lightModeDividerColor,
+      light: '#BAACA5',
     },
     secondary: {
       main: SecondaryMainColor,
@@ -148,12 +152,12 @@ let rusticLightTheme = createTheme({
       paper: whiteColor,
     },
     action: {
-      active: '#5F5C5A',
-      hover: '#F1ECEA',
-      selected: lightModeDisabledColor,
-      disabledBackground: '#E5E5E5',
-      focus: lightModeBackgroundDefaultColor,
-      disabled: lightModeDisabledColor,
+      active: actionActiveColor,
+      hover: '#EFEAEA',
+      selected: actionSelectedColor,
+      disabledBackground: actionDisabledBackgroundColor,
+      focus: actionFocusColor,
+      disabled: actionDisabledColor,
     },
   },
   components: {
@@ -169,13 +173,14 @@ let rusticLightTheme = createTheme({
 })
 
 const darkModePaperColor = '#2F2F2F'
-const darkModePrimraryMainColor = '#FFFCFB'
+const darkModePrimaryMainColor = '#FFFCFB'
 let rusticDarkTheme = createTheme({
   ...baseTheme,
   palette: {
     mode: 'dark',
+    divider: dividerColor,
     primary: {
-      main: darkModePrimraryMainColor,
+      main: darkModePrimaryMainColor,
       dark: SecondaryDarkColor,
       light: '#FFDBCC',
     },
@@ -188,26 +193,25 @@ let rusticDarkTheme = createTheme({
       default: '#040404',
       paper: darkModePaperColor,
     },
-    divider: '#D0C4BE',
     text: {
       primary: whiteColor,
       secondary: '#EBEBEB',
       disabled: '#C1C1C1',
     },
     action: {
-      active: '#5F5C5A',
+      active: actionActiveColor,
       hover: '#9A9A9A',
-      selected: '#D6D0D0',
-      focus: '#FDFDFD',
-      disabledBackground: '#E5E5E5',
-      disabled: '#C7C2C0',
+      selected: actionSelectedColor,
+      focus: actionFocusColor,
+      disabledBackground: actionDisabledBackgroundColor,
+      disabled: actionDisabledColor,
     },
   },
   components: {
     MuiTooltip: {
       styleOverrides: {
         tooltip: {
-          backgroundColor: darkModePrimraryMainColor,
+          backgroundColor: darkModePrimaryMainColor,
           color: darkModePaperColor,
         },
       },


### PR DESCRIPTION
## Changes
- Popup menu didn't show the dark mode background color correctively before. This PR hides Mui's default background image to show background color properly
- Update theme based on design (minor color changes)
## Design

<img width="423" alt="Screenshot 2024-04-02 at 9 37 20 AM" src="https://github.com/rustic-ai/ui-components/assets/103023797/649bac59-3103-4ce5-8228-976d12e81ccb">
<img width="417" alt="Screenshot 2024-04-02 at 9 37 28 AM" src="https://github.com/rustic-ai/ui-components/assets/103023797/ca382098-ffc0-444d-bbf0-c1c982ee3bd7">
<img width="133" alt="Screenshot 2024-04-01 at 2 30 21 PM" src="https://github.com/rustic-ai/ui-components/assets/103023797/9b86fadc-a88b-486b-8a29-4d9db1587319">

## Before
<img width="325" alt="Screenshot 2024-04-01 at 11 23 36 AM" src="https://github.com/rustic-ai/ui-components/assets/103023797/1edf976c-b0a1-4d57-b259-c1435282ae44">

## After


<img width="296" alt="Screenshot 2024-04-02 at 9 34 39 AM" src="https://github.com/rustic-ai/ui-components/assets/103023797/70781db3-785a-4f04-83a3-4e39a6c032c1">
