### PR TITLE
feat(transcript): create reusable Transcript component

### DIFF
--- a/src/components/media/transcript/transcript.css
+++ b/src/components/media/transcript/transcript.css
@@ -1,0 +1,5 @@
+.rustic-transcript-header {
+  margin-block: 16px;
+  padding-left: 16px;
+  text-transform: none;
+}

--- a/src/components/media/transcript/transcript.tsx
+++ b/src/components/media/transcript/transcript.tsx
@@ -1,0 +1,33 @@
+import './transcript.css'
+
+import { useTheme } from '@mui/material'
+import Typography from '@mui/material/Typography'
+import React from 'react'
+
+interface TranscriptProps {
+  title?: string
+  transcript: string
+}
+
+export default function Transcript(props: TranscriptProps) {
+  const theme = useTheme()
+  return (
+    <>
+      <Typography
+        className="rustic-transcript-header"
+        variant="overline"
+        color="text.secondary"
+        sx={{ borderLeft: `4px solid ${theme.palette.divider}` }}
+      >
+        {props.title}
+      </Typography>
+      <Typography data-cy="transcript" variant="body2">
+        {props.transcript}
+      </Typography>
+    </>
+  )
+}
+
+Transcript.defaultProps = {
+  title: 'Transcript',
+}


### PR DESCRIPTION
## Changes
- create reusable `Transcript` component for media components (ex. `Video`, `Sound`, `Voice`, etc)

## Design
### Transcript used in `Video` component
![Screenshot 2024-04-02 at 3 47 42 PM](https://github.com/rustic-ai/ui-components/assets/111031789/971b8836-c907-4d5d-9a92-fffd6eb13c2a)

## Implementation
### Usage in upcoming `Sound` component
![Screenshot 2024-04-02 at 3 55 03 PM](https://github.com/rustic-ai/ui-components/assets/111031789/abc90dea-e7b3-4c25-9444-c07a52a6812b)
