### PR TITLE
fix!: update rechartsTimeSeries and extract timeSeriesWrapper

### DIFF
--- a/src/components/chart/rechartsTimeSeries.cy.tsx
+++ b/src/components/chart/rechartsTimeSeries.cy.tsx
@@ -31,8 +31,6 @@ describe('TimeSeries', () => {
   const areaChart = '[data-cy="area-chart"]'
   const referenceLineLabel = 'reference-line-label'
 
-  const chartColors = ['#648FFF', '#785EF0', '#DC267F', '#FE6100', '#FFB000']
-
   beforeEach(() => {
     cy.mount(
       <RechartsTimeSeries
@@ -41,7 +39,6 @@ describe('TimeSeries', () => {
         description="This is a description"
         referenceLineYAxis={[exampleReferenceLineYAxis]}
         referenceLineLabel={[referenceLineLabel]}
-        chartColors={chartColors}
       />
     )
   })
@@ -113,7 +110,6 @@ describe('TimeSeries', () => {
           title="title"
           description="This is a description"
           referenceLineYAxis={[exampleReferenceLineYAxis]}
-          chartColors={chartColors}
         />
       )
 
@@ -129,7 +125,6 @@ describe('TimeSeries', () => {
           description="This is a description"
           disableChartTypeToggle={true}
           defaultChartType="area"
-          chartColors={chartColors}
         />
       )
       cy.get(menuIcon).should('not.exist')

--- a/src/components/chart/rechartsTimeSeries.stories.tsx
+++ b/src/components/chart/rechartsTimeSeries.stories.tsx
@@ -1,21 +1,12 @@
 /* eslint-disable no-magic-numbers */
+import type { Meta } from '@storybook/react'
+
 import RechartsTimeSeries from './rechartsTimeSeries'
 
-export default {
+const meta: Meta<React.ComponentProps<typeof RechartsTimeSeries>> = {
   title: 'Rustic UI/Chart/Recharts Time Series',
   component: RechartsTimeSeries,
   tags: ['autodocs'],
-  argTypes: {
-    timeSeries: {
-      control: 'array',
-      description:
-        'Data to be displayed in the time series chart. The first field is used as the x-axis field. We currently support formatting timestamps in seconds and milliseconds. Other data types will be displayed as given. \n<pre>```interface TimeSeriesData {\n  timestamp: number\n  [key: string]: number\n}```</pre>',
-    },
-    chartContainerMargin: {
-      description:
-        'Margin of chart container in pixel. For example, adding left margin could show larger numbers properly.\n<pre>```interface Margin {\n  top?: number\n  right?: number\n  bottom?: number\n  left?: number\n}```</pre>',
-    },
-  },
   parameters: {
     layout: 'centered',
     docs: {
@@ -27,7 +18,57 @@ export default {
   },
 }
 
-const chartColors = ['#648FFF', '#785EF0', '#DC267F', '#FE6100', '#FFB000']
+meta.argTypes = {
+  ...meta.argTypes,
+  timeSeries: {
+    table: {
+      type: {
+        summary: 'Array of TimeSeriesDataset.\n',
+        detail:
+          'Each TimeSeriesDataset has the following fields:\n' +
+          '  timestamp: timestamp in milliseconds  \n' +
+          '  [key: string]: data for other data fields',
+      },
+    },
+  },
+  chartColors: {
+    table: {
+      type: {
+        summary: 'ChartColors object.\n',
+        detail:
+          "ChartColors can have multiple fields and each field should be the name of a dataKey, e.g. 'uv'\n" +
+          'Each field could have the following properties\n' +
+          '  stroke: Optional stroke color for a specific dataKey \n' +
+          '  fill: Optional fill color for a specific dataKey',
+      },
+    },
+  },
+  chartSpacing: {
+    table: {
+      type: {
+        summary: 'ChartSpacing object.\n',
+        detail:
+          'ChartSpacing has the following fields:\n' +
+          '  top: the number value of top padding/margin in pixels \n' +
+          '  right: the number value of right padding/margin in pixels  \n' +
+          '  bottom: the number value of bottom padding/margin in pixels  \n' +
+          '  left: the number value of left padding/margin in pixels',
+      },
+    },
+  },
+  updatedData: {
+    table: {
+      type: {
+        summary: 'An array of TimeSeriesFormat.\n',
+        detail:
+          'All of the fields listed above could be used.\n' +
+          'Normally only timeSeries is used to update the chart.',
+      },
+    },
+  },
+}
+
+export default meta
 
 const oneDayData = [
   {
@@ -114,8 +155,6 @@ export const Default = {
     timeSeries: manyDaysData,
     description:
       'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.',
-    yAxisLabelWidth: 60,
-    chartColors,
   },
 }
 
@@ -157,7 +196,6 @@ export const MultipleReferenceLines = {
 export const NoTitleAndDescription = {
   args: {
     timeSeries: oneDayData,
-    chartColors,
   },
 }
 
@@ -166,7 +204,6 @@ export const CustomizedWidthAndAspect = {
     timeSeries: oneDayData,
     width: 400,
     aspectRatio: 1,
-    chartColors,
   },
 }
 
@@ -176,7 +213,6 @@ export const NoTimeSeriesData = {
     description:
       'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.',
     timeSeries: [],
-    chartColors,
   },
 }
 
@@ -188,7 +224,6 @@ export const BarChartWithoutChartTypeToggle = {
     timeSeries: oneDayData,
     disableChartTypeToggle: true,
     defaultChartType: 'bar',
-    chartColors,
   },
 }
 
@@ -203,7 +238,17 @@ export const FormatData = {
       `${value / 1000000}M`,
       name,
     ],
-    chartContainerMargin: { top: 20, left: 25, right: 25, bottom: 20 },
-    chartColors,
+    chartSpacing: { top: 20, left: 25, right: 25, bottom: 20 },
+  },
+}
+
+export const CustomizeColors = {
+  args: {
+    ...Default.args,
+    chartColors: {
+      uv: { fill: '#A6EFA7', stroke: '#6BAB6C' },
+      pv: { fill: '#F2FB8B', stroke: '#FFB000' },
+      amt: { fill: '#C5B9F9', stroke: '#4C3B9A' },
+    },
   },
 }

--- a/src/components/chart/rechartsTimeSeries.tsx
+++ b/src/components/chart/rechartsTimeSeries.tsx
@@ -1,11 +1,6 @@
 import './rechartsTimeSeries.css'
 
 import Crop32Icon from '@mui/icons-material/Crop169'
-import MoreVertIcon from '@mui/icons-material/MoreVert'
-import FormControl from '@mui/material/FormControl'
-import IconButton from '@mui/material/IconButton'
-import Menu from '@mui/material/Menu'
-import MenuItem from '@mui/material/MenuItem'
 import Typography from '@mui/material/Typography'
 import Box from '@mui/system/Box'
 import { Fragment, useEffect, useState } from 'react'
@@ -25,71 +20,27 @@ import {
   YAxis,
 } from 'recharts'
 
+import { defaultChartStrokeColors } from '../../rusticTheme'
+import { defaultTimeSeriesProps } from '../defaultProps'
 import { calculateTimeDiffInDays, formatTimestampLabel } from '../helper'
-
-export interface TimeSeriesData {
-  timestamp: number
-  [key: string]: number
-}
-
-export interface Margin {
-  top?: number
-  right?: number
-  bottom?: number
-  left?: number
-}
-
-export interface RechartsTimeSeriesProps {
-  /** Data to be displayed in the time series chart. The first field is used as the x-axis field. We currently support formatting epoch timestamps and ISO date strings. Other data types will be displayed as given. */
-  timeSeries: TimeSeriesData[]
-  /** An array containing a predefined set of Hex color codes or string colors (e.g. 'blue'). The colors will be applied to the keys of the data object in order. */
-  chartColors: string[]
-  /** Array of y-axis reference lines. */
-  referenceLineYAxis?: number[]
-  /** Array of y-axis reference line colors. Hex color codes and string colors are both supported for defining colors. If not provided, all lines default to grey. Skip providing a custom color for a certain y-axis by providing an empty string. */
-  referenceLineColor?: string[]
-  /** Array of y-axis reference line labels. Skip providing a custom label for a certain y-axis by providing an empty string. */
-  referenceLineLabel?: string[]
-  /** Array of y-axis reference line stroke widths. If not provided, all lines default to 1. Skip providing a custom stroke width for a certain y-axis by providing an empty string. */
-  referenceLineStrokeWidth?: number[]
-  /** Title of the time series chart. */
-  title?: string
-  /** Description of the time series chart. */
-  description?: string
-  // TODO: define onClick type - task <5991977827>
-  /** Callback function to be called when a point on the graph is clicked. */
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  onClick?: (...args: any[]) => any
-  /** Width of the y-axis labels in pixels. */
-  yAxisLabelWidth?: number
-  /** Minimum width of the chart in pixels. */
-  minChartWidth?: number
-  /** Maximum width of the chart in pixels. */
-  maxHeight?: number
-  /** Updated data will be added to the original time series data. */
-  updatedData?: { timeSeries: TimeSeriesData[] }[]
-  /** Aspect ratio of the chart. */
-  aspectRatio?: number
-  /** Width of the chart in pixels. */
-  width?: number
-  /** Chart type toggle will be hidden if the value is true. */
-  disableChartTypeToggle?: boolean
-  /** Define the default chart type: `line`, `bar`, or `area`. */
-  defaultChartType?: TimeSeriesType
-  /** Pass a function to format y-axis label. Make sure to use tooltipFormatter and yAxisTickFormatter together so that the numbers are uniform. */
-  yAxisTickFormatter?: (value: number) => string
-  /** Pass a function to format tooltip content. */
-  tooltipFormatter?: (value: number, name: string) => [string, string]
-  /** Margin of chart container in pixel. For example, adding left margin could show larger numbers properly. */
-  chartContainerMargin?: Margin
-}
-
-export type TimeSeriesType = 'line' | 'bar' | 'area'
-
+import type {
+  TimeSeriesData,
+  TimeSeriesDataset,
+  TimeSeriesType,
+} from '../types'
+import TimeSeriesWrapper from './timeSeriesWrapper'
 const TimeSeriesComponents = {
   line: LineChart,
   bar: BarChart,
   area: AreaChart,
+}
+
+export interface RechartsTimeSeriesData extends TimeSeriesData {
+  /** Callback function to be called when a data point on the graph is clicked. */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  onClick?: (...args: any[]) => any
+  /** Pass a function to format tooltip content. */
+  tooltipFormatter?: (value: number, name: string) => [string, string]
 }
 
 //All of lines should be shown initially
@@ -107,12 +58,13 @@ function areAllDatasetsVisible(datasetsVisibility: { [key: string]: boolean }) {
   return Object.values(datasetsVisibility).every((value) => value === true)
 }
 
-function RechartsTimeSeries(props: RechartsTimeSeriesProps) {
+function RechartsTimeSeries(props: RechartsTimeSeriesData) {
   const [timeSeriesType, setTimeSeriesType] = useState<TimeSeriesType>(
     props.defaultChartType || 'line'
   )
-  const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null)
-  const [timeSeries, setTimeSeries] = useState<object[]>(props.timeSeries)
+  const [timeSeries, setTimeSeries] = useState<TimeSeriesDataset[]>(
+    props.timeSeries
+  )
 
   const dataFields = timeSeries.length > 0 ? Object.keys(timeSeries[0]) : []
   const xAxisField = dataFields[0]
@@ -133,15 +85,6 @@ function RechartsTimeSeries(props: RechartsTimeSeriesProps) {
   }, [props.timeSeries, props.updatedData])
 
   const TimeSeriesParentComponent = TimeSeriesComponents[timeSeriesType]
-
-  function handleChartTypeToggle(event?: React.MouseEvent<HTMLElement>) {
-    anchorEl ? setAnchorEl(null) : event && setAnchorEl(event.currentTarget)
-  }
-
-  function handleChartTypeClick(chartType: TimeSeriesType) {
-    setTimeSeriesType(chartType)
-    handleChartTypeToggle()
-  }
 
   function handleLegendClick(clickedDataKey: string) {
     const isTheOnlyVisibleDataset =
@@ -172,10 +115,36 @@ function RechartsTimeSeries(props: RechartsTimeSeriesProps) {
     }
   }
 
+  function getDefaultStrokeColor(index: number) {
+    const colorIndex = index % defaultChartStrokeColors.length
+    return defaultChartStrokeColors[colorIndex]
+  }
+
+  function getStrokeColor(key: string, index: number) {
+    if (props.chartColors && props.chartColors[key].stroke) {
+      return props.chartColors[key].stroke
+    } else {
+      return getDefaultStrokeColor(index)
+    }
+  }
+
   function renderChartComponent(key: string, index: number) {
-    const colorIndex = index % props.chartColors.length
-    const chartColor = datasetsVisibility[key]
-      ? props.chartColors[colorIndex]
+    const chartStrokeColor = datasetsVisibility[key]
+      ? getStrokeColor(key, index)
+      : 'transparent'
+
+    function getFillColor(key: string) {
+      if (datasetsVisibility[key]) {
+        if (props.chartColors && props.chartColors[key].fill) {
+          return props.chartColors[key].fill
+        } else {
+          return getDefaultStrokeColor(index)
+        }
+      }
+    }
+
+    const chartFillColor = datasetsVisibility[key]
+      ? getFillColor(key)
       : 'transparent'
 
     const onClickFields = {
@@ -194,7 +163,7 @@ function RechartsTimeSeries(props: RechartsTimeSeriesProps) {
             name={key}
             key={key}
             dot={false}
-            stroke={chartColor}
+            stroke={chartStrokeColor}
             activeDot={props.onClick && onClickFields}
           />
         )
@@ -203,7 +172,8 @@ function RechartsTimeSeries(props: RechartsTimeSeriesProps) {
           <Bar
             key={key}
             dataKey={key}
-            fill={chartColor}
+            //Recharts doesn't support stroke very well. By default, tooltip use the fill color for tooltip label.
+            fill={chartStrokeColor}
             onClick={props.onClick && onClickFields.onClick}
             cursor={props.onClick && onClickFields.cursor}
           />
@@ -213,8 +183,16 @@ function RechartsTimeSeries(props: RechartsTimeSeriesProps) {
           <Fragment key={key}>
             <defs>
               <linearGradient id={`color${key}`} x1="0" y1="0" x2="0" y2="1">
-                <stop offset="5%" stopColor={chartColor} stopOpacity={0.8} />
-                <stop offset="95%" stopColor={chartColor} stopOpacity={0} />
+                <stop
+                  offset="5%"
+                  stopColor={chartFillColor}
+                  stopOpacity={0.8}
+                />
+                <stop
+                  offset="95%"
+                  stopColor={chartFillColor}
+                  stopOpacity={0.1}
+                />
               </linearGradient>
             </defs>
             <Area
@@ -222,7 +200,7 @@ function RechartsTimeSeries(props: RechartsTimeSeriesProps) {
               isAnimationActive={false}
               dataKey={key}
               type="monotone"
-              stroke={chartColor}
+              stroke={chartStrokeColor}
               fillOpacity={1}
               fill={`url(#color${key})`}
               activeDot={props.onClick && onClickFields}
@@ -233,9 +211,7 @@ function RechartsTimeSeries(props: RechartsTimeSeriesProps) {
   }
 
   function getLegendColor(dataKey: string, index: number): string {
-    return datasetsVisibility[dataKey]
-      ? props.chartColors[index % props.chartColors.length]
-      : 'grey'
+    return datasetsVisibility[dataKey] ? getStrokeColor(dataKey, index) : 'grey'
   }
 
   function getLegendTextDecorationStyle(dataKey: string): string {
@@ -273,161 +249,87 @@ function RechartsTimeSeries(props: RechartsTimeSeriesProps) {
     )
   }
 
-  if (timeSeries.length === 0) {
-    return <Typography variant="body2">No data available</Typography>
-  } else {
+  let timeSeriesDuration: number
+  if (props.timeSeries.length > 0) {
     const lastTimeSeriesItem = props.timeSeries[props.timeSeries.length - 1]
     const firstTimeSeriesItem = props.timeSeries[0]
 
-    const timeSeriesDuration = calculateTimeDiffInDays(
+    timeSeriesDuration = calculateTimeDiffInDays(
       firstTimeSeriesItem[xAxisField],
       lastTimeSeriesItem[xAxisField]
     )
-
-    return (
-      <Box
-        className="rustic-recharts-time-series"
-        data-cy={`${timeSeriesType}-chart`}
-      >
-        {!props.disableChartTypeToggle && (
-          <FormControl className="rustic-recharts-time-series-chart-toggle">
-            <IconButton
-              aria-label="chart options"
-              aria-expanded={Boolean(anchorEl)}
-              aria-haspopup="true"
-              onClick={handleChartTypeToggle}
-            >
-              <MoreVertIcon sx={{ color: 'primary.main' }} />
-            </IconButton>
-            <Menu
-              anchorOrigin={{
-                vertical: 'bottom',
-                horizontal: 'right',
-              }}
-              transformOrigin={{
-                vertical: 'top',
-                horizontal: 'right',
-              }}
-              anchorEl={anchorEl}
-              open={Boolean(anchorEl)}
-              onClose={(e: React.MouseEvent<HTMLElement>) =>
-                handleChartTypeToggle(e)
-              }
-            >
-              <Typography className="rustic-recharts-time-series-chart-toggle-title">
-                Chart Types:
-              </Typography>
-              {Object.keys(TimeSeriesComponents).map((chartType) => {
-                return (
-                  <MenuItem
-                    value={chartType}
-                    key={chartType}
-                    selected={chartType === timeSeriesType}
-                    onClick={() =>
-                      handleChartTypeClick(chartType as TimeSeriesType)
-                    }
-                  >
-                    {chartType.charAt(0).toUpperCase() + chartType.slice(1)}{' '}
-                    Chart
-                  </MenuItem>
-                )
-              })}
-            </Menu>
-          </FormControl>
-        )}
-        <Box>
-          {props.title && (
-            <Typography
-              variant="subtitle2"
-              className="rustic-recharts-time-series-title"
-              data-cy="time-series-title"
-            >
-              {props.title}
-            </Typography>
-          )}
-
-          {props.description && (
-            <Typography
-              variant="caption"
-              className="rustic-recharts-time-series-description"
-            >
-              {props.description}
-            </Typography>
-          )}
-
-          <ResponsiveContainer
-            aspect={props.aspectRatio}
-            width={props.width}
-            maxHeight={props.maxHeight}
-            minWidth={props.minChartWidth}
-          >
-            <TimeSeriesParentComponent
-              data={timeSeries}
-              margin={props.chartContainerMargin}
-            >
-              <XAxis
-                dataKey={xAxisField}
-                tickFormatter={(value) =>
-                  formatTimestampLabel(value, timeSeriesDuration)
-                }
-              />
-              <YAxis
-                domain={['auto', 'auto']}
-                width={props.yAxisLabelWidth}
-                tickFormatter={props.yAxisTickFormatter}
-              />
-              <Tooltip
-                labelFormatter={(label: number) => [
-                  formatTimestampLabel(label, timeSeriesDuration),
-                ]}
-                formatter={props.tooltipFormatter}
-              />
-              <Legend content={renderLegend} />
-
-              {yAxisFields.map((key, index) =>
-                datasetsVisibility[key]
-                  ? renderChartComponent(key, index)
-                  : null
-              )}
-              {props.referenceLineYAxis &&
-                props.referenceLineYAxis.map((referenceLine, index) => {
-                  return (
-                    <ReferenceLine
-                      key={index}
-                      y={referenceLine}
-                      label={
-                        props.referenceLineLabel &&
-                        props.referenceLineLabel[index]
-                      }
-                      stroke={
-                        props.referenceLineColor &&
-                        props.referenceLineColor[index]
-                      }
-                      strokeDasharray="3 3"
-                      ifOverflow="extendDomain"
-                      strokeWidth={
-                        props.referenceLineStrokeWidth &&
-                        props.referenceLineStrokeWidth[index]
-                      }
-                      isFront
-                    />
-                  )
-                })}
-            </TimeSeriesParentComponent>
-          </ResponsiveContainer>
-        </Box>
-      </Box>
-    )
   }
+
+  return (
+    <TimeSeriesWrapper
+      timeSeriesType={timeSeriesType}
+      setTimeSeriesType={setTimeSeriesType}
+      timeSeries={props.timeSeries}
+      disableChartTypeToggle={props.disableChartTypeToggle}
+      title={props.title}
+      description={props.description}
+    >
+      <ResponsiveContainer
+        aspect={props.aspectRatio}
+        width={props.width}
+        maxHeight={props.maxHeight}
+        minWidth={props.minChartWidth}
+      >
+        <TimeSeriesParentComponent
+          data={timeSeries}
+          margin={props.chartSpacing}
+        >
+          <XAxis
+            dataKey={xAxisField}
+            tickFormatter={(value) =>
+              formatTimestampLabel(value, timeSeriesDuration)
+            }
+          />
+          <YAxis
+            domain={['auto', 'auto']}
+            tickFormatter={props.yAxisTickFormatter}
+          />
+          <Tooltip
+            labelFormatter={(label: number) => [
+              formatTimestampLabel(label, timeSeriesDuration),
+            ]}
+            formatter={props.tooltipFormatter}
+          />
+          <Legend content={renderLegend} />
+
+          {yAxisFields.map((key, index) =>
+            datasetsVisibility[key] ? renderChartComponent(key, index) : null
+          )}
+          {props.referenceLineYAxis &&
+            props.referenceLineYAxis.map((referenceLine, index) => {
+              return (
+                <ReferenceLine
+                  key={index}
+                  y={referenceLine}
+                  label={
+                    props.referenceLineLabel && props.referenceLineLabel[index]
+                  }
+                  stroke={
+                    props.referenceLineColor && props.referenceLineColor[index]
+                  }
+                  strokeDasharray="3 3"
+                  ifOverflow="extendDomain"
+                  strokeWidth={
+                    props.referenceLineStrokeWidth &&
+                    props.referenceLineStrokeWidth[index]
+                  }
+                  isFront
+                />
+              )
+            })}
+        </TimeSeriesParentComponent>
+      </ResponsiveContainer>
+    </TimeSeriesWrapper>
+  )
 }
 
 RechartsTimeSeries.defaultProps = {
-  minChartWidth: 200,
-  maxHeight: 600,
-  yAxisLabelWidth: 30,
-  // eslint-disable-next-line no-magic-numbers
-  aspectRatio: 16 / 9,
-  disableChartTypeToggle: false,
+  ...defaultTimeSeriesProps,
 }
 
 export default RechartsTimeSeries

--- a/src/components/chart/timeSeriesWrapper.tsx
+++ b/src/components/chart/timeSeriesWrapper.tsx
@@ -1,0 +1,111 @@
+import MoreVertIcon from '@mui/icons-material/MoreVert'
+import FormControl from '@mui/material/FormControl'
+import IconButton from '@mui/material/IconButton'
+import Menu from '@mui/material/Menu'
+import MenuItem from '@mui/material/MenuItem'
+import Typography from '@mui/material/Typography'
+import Box from '@mui/system/Box'
+import React, { type Dispatch, type ReactNode, useState } from 'react'
+
+import type { TimeSeriesDataset, TimeSeriesType } from '../types'
+
+export type TimeSeriesWrapper = {
+  children: ReactNode
+  disableChartTypeToggle?: boolean
+  timeSeriesType: TimeSeriesType
+  setTimeSeriesType: Dispatch<React.SetStateAction<TimeSeriesType>>
+  timeSeries: TimeSeriesDataset[]
+  title?: string
+  description?: string
+}
+
+export default function TimeSeriesWrapper(props: TimeSeriesWrapper) {
+  const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null)
+
+  const timeSeriesTypes = ['line', 'bar', 'area']
+
+  function handleChartTypeToggle(event?: React.MouseEvent<HTMLElement>) {
+    anchorEl ? setAnchorEl(null) : event && setAnchorEl(event.currentTarget)
+  }
+
+  function handleChartTypeClick(chartType: TimeSeriesType) {
+    props.setTimeSeriesType(chartType)
+    handleChartTypeToggle()
+  }
+
+  if (props.timeSeries.length === 0) {
+    return <Typography variant="body2">No data available</Typography>
+  }
+
+  return (
+    <Box className="rustic-recharts-time-series">
+      {/* will be replaced by a dropdown menu in a follow up */}
+      {!props.disableChartTypeToggle && (
+        <FormControl className="rustic-recharts-time-series-chart-toggle">
+          <IconButton
+            aria-label="chart options"
+            aria-expanded={Boolean(anchorEl)}
+            aria-haspopup="true"
+            onClick={handleChartTypeToggle}
+          >
+            <MoreVertIcon sx={{ color: 'primary.main' }} />
+          </IconButton>
+          <Menu
+            anchorOrigin={{
+              vertical: 'bottom',
+              horizontal: 'right',
+            }}
+            transformOrigin={{
+              vertical: 'top',
+              horizontal: 'right',
+            }}
+            anchorEl={anchorEl}
+            open={Boolean(anchorEl)}
+            onClose={(e: React.MouseEvent<HTMLElement>) =>
+              handleChartTypeToggle(e)
+            }
+          >
+            <Typography className="rustic-recharts-time-series-chart-toggle-title">
+              Chart Types:
+            </Typography>
+            {timeSeriesTypes.map((chartType) => {
+              return (
+                <MenuItem
+                  value={chartType}
+                  key={chartType}
+                  selected={chartType === props.timeSeriesType}
+                  onClick={() => {
+                    return handleChartTypeClick(chartType as TimeSeriesType)
+                  }}
+                >
+                  {chartType.charAt(0).toUpperCase() + chartType.slice(1)} Chart
+                </MenuItem>
+              )
+            })}
+          </Menu>
+        </FormControl>
+      )}
+      <Box data-cy={`${props.timeSeriesType}-chart`}>
+        {props.title && (
+          <Typography
+            variant="subtitle2"
+            className="rustic-recharts-time-series-title"
+            data-cy="time-series-title"
+          >
+            {props.title}
+          </Typography>
+        )}
+
+        {props.description && (
+          <Typography
+            variant="caption"
+            className="rustic-recharts-time-series-description"
+          >
+            {props.description}
+          </Typography>
+        )}
+        {props.children}
+      </Box>
+    </Box>
+  )
+}

--- a/src/components/defaultProps.ts
+++ b/src/components/defaultProps.ts
@@ -1,0 +1,7 @@
+export const defaultTimeSeriesProps = {
+  minChartWidth: 200,
+  maxHeight: 600,
+  // eslint-disable-next-line no-magic-numbers
+  aspectRatio: 16 / 9,
+  disableChartTypeToggle: false,
+}

--- a/src/components/types.ts
+++ b/src/components/types.ts
@@ -135,3 +135,57 @@ export interface TableFormat extends DataFormat {
 }
 
 export type TableData = TableFormat & Updates<TableFormat>
+
+export interface TimeSeriesDataset {
+  timestamp: number
+  [key: string]: number
+}
+
+export interface ChartSpacing {
+  top?: number
+  right?: number
+  bottom?: number
+  left?: number
+}
+
+export type TimeSeriesType = 'line' | 'bar' | 'area'
+
+export type ChartColors = {
+  [key: string]: {
+    stroke: string
+    fill: string
+  }
+}
+
+export interface TimeSeriesFormat extends DataFormat {
+  /** Data to be displayed in the time series chart. The first field is used as the x-axis field. We currently support formatting epoch timestamps and ISO date strings. Other data types will be displayed as given. */
+  timeSeries: TimeSeriesDataset[]
+  /** Used to customize chart colors. An object containing a predefined set of CSS Colors. Hex, RGB, cross-browser color names as well as other color methods (See https://developer.mozilla.org/en-US/docs/Web/CSS/color_value) are supported. If not provided, default colors will be applied. */
+  chartColors?: ChartColors
+  /** Array of y-axis reference lines. */
+  referenceLineYAxis?: number[]
+  /** Array of y-axis reference line colors. Hex color codes and string colors are both supported for defining colors. If not provided, all lines default to grey. Skip providing a custom color for a certain y-axis by providing an empty string. */
+  referenceLineColor?: string[]
+  /** Array of y-axis reference line labels. Skip providing a custom label for a certain y-axis by providing an empty string. */
+  referenceLineLabel?: string[]
+  /** Array of y-axis reference line stroke widths. If not provided, all lines default to 1. Skip providing a custom stroke width for a certain y-axis by providing an empty string. */
+  referenceLineStrokeWidth?: number[]
+  /** Aspect ratio of the chart. */
+  aspectRatio?: number
+  /** Width of the chart in pixels. */
+  width?: number
+  /** Chart type toggle will be hidden if the value is true. */
+  disableChartTypeToggle?: boolean
+  /** Define the default chart type: `line`, `bar`, or `area`. */
+  defaultChartType?: TimeSeriesType
+  /** Minimum width of the chart in pixels. */
+  minChartWidth?: number
+  /** Maximum width of the chart in pixels. */
+  maxHeight?: number
+  /** Pass a function to format y-axis label. Make sure to use tooltipFormatter and yAxisTickFormatter together so that the numbers are uniform. */
+  yAxisTickFormatter?: (value: number) => string
+  /** Spacing around the chart container in pixels. Depending on the charting library, this field is used to add either padding or margin.*/
+  chartSpacing?: ChartSpacing
+}
+
+export type TimeSeriesData = TimeSeriesFormat & Updates<TimeSeriesFormat>

--- a/src/rusticTheme.ts
+++ b/src/rusticTheme.ts
@@ -2,6 +2,17 @@
 import type { Shadows } from '@mui/material/styles'
 import { createTheme, responsiveFontSizes } from '@mui/material/styles'
 
+export const defaultChartStrokeColors = [
+  '#CC79A7',
+  '#E69F00',
+  '#56B4E9',
+  '#009E73',
+  '#F0E442',
+  '#0072B2',
+  '#D55E00',
+  '#000000',
+]
+
 const whiteColor = '#FFFFFF'
 const SecondaryMainColor = '#FF6928'
 const SecondaryDarkColor = '#E54500'


### PR DESCRIPTION
## Changes
- Update `rechartsTimeSeries` 
  - Update the structure of `chartColors`. Change it to an optional props so that people don't have to pass colors if they don't want customization. Default stroke colors are added for Recharts. Fill color is added because we need it in Chartjs to support color customization. 
  - Rename `chartContainerMargin` =>`chartSpacing` (because Chartjs can only add padding. `chartSpacing` is more generalized)
  - Default props is stored in the helper file right now. It could be used by other time series components in the future e.g. `chartjsTimeSeries`. I am wondering if there's a better place that I could store this.
  - Stories and tests are updated.
  - (I didn't add `onClick` and `tooltipFormatter` to `TimeSeriesData` because charting libraries have different types for them)
- Extract `timeSeriesWrapper` component. Currently, it has title, description and chart type toggle. Chart type toggle will be updated later

## Before
<img width="942" alt="Screenshot 2024-04-04 at 3 59 33 PM" src="https://github.com/rustic-ai/ui-components/assets/103023797/660462dc-8bbb-4b31-9794-883e94c69d62">
<img width="1014" alt="Screenshot 2024-04-04 at 3 59 50 PM" src="https://github.com/rustic-ai/ui-components/assets/103023797/c6a64e13-5619-4452-ae93-60d58d58258c">
<img width="1016" alt="Screenshot 2024-04-04 at 3 59 57 PM" src="https://github.com/rustic-ai/ui-components/assets/103023797/b24ba289-a5ce-479d-95d5-a124dca4caa2">
<img width="1025" alt="Screenshot 2024-04-04 at 4 00 22 PM" src="https://github.com/rustic-ai/ui-components/assets/103023797/ce0c7cfc-6480-4e4f-9040-1c2596164390">
<img width="1022" alt="Screenshot 2024-04-04 at 4 00 40 PM" src="https://github.com/rustic-ai/ui-components/assets/103023797/45ad8649-1f43-4aa2-9917-3fd3837ed8a6">
<img width="1025" alt="Screenshot 2024-04-04 at 4 00 46 PM" src="https://github.com/rustic-ai/ui-components/assets/103023797/4323dc65-ecd8-4349-9549-f86f9876e876">
<img width="1020" alt="Screenshot 2024-04-04 at 4 00 51 PM" src="https://github.com/rustic-ai/ui-components/assets/103023797/28483fe3-e8fc-48e2-b3db-98b7f5d5ee6f">
<img width="1041" alt="Screenshot 2024-04-04 at 4 00 58 PM" src="https://github.com/rustic-ai/ui-components/assets/103023797/b170d18b-a19a-4583-ab5c-eb275001233c">
<img width="1036" alt="Screenshot 2024-04-04 at 4 01 05 PM" src="https://github.com/rustic-ai/ui-components/assets/103023797/1ed482a9-a9e3-4c74-b3cc-99ec1358617e">
<img width="1028" alt="Screenshot 2024-04-04 at 4 01 12 PM" src="https://github.com/rustic-ai/ui-components/assets/103023797/02a98225-c575-468a-b41e-6690a101c41a">

## After
![Screenshot 2024-04-04 at 11 32 26 PM](https://github.com/rustic-ai/ui-components/assets/103023797/c4ae6a31-4985-411f-a091-b0bbb830bcb0)
![Screenshot 2024-04-04 at 11 32 38 PM](https://github.com/rustic-ai/ui-components/assets/103023797/4e103f72-63b7-4375-86f6-c924913724ba)
![Screenshot 2024-04-04 at 11 40 34 PM](https://github.com/rustic-ai/ui-components/assets/103023797/2c14c02d-4c93-4d70-960c-a84e53992542)
![Screenshot 2024-04-04 at 11 40 43 PM](https://github.com/rustic-ai/ui-components/assets/103023797/a4792b13-73d1-46a1-9698-d20d2359e661)


![Screenshot 2024-04-04 at 11 40 54 PM](https://github.com/rustic-ai/ui-components/assets/103023797/3bd82498-d02b-4eb9-86ef-5967167ec79d)
![Screenshot 2024-04-04 at 11 41 04 PM](https://github.com/rustic-ai/ui-components/assets/103023797/3ad04622-3b54-4c37-957b-47e517a89eec)
![Screenshot 2024-04-04 at 11 41 11 PM](https://github.com/rustic-ai/ui-components/assets/103023797/34bd0352-d54d-456a-b392-817614d965c8)
![Screenshot 2024-04-04 at 11 41 17 PM](https://github.com/rustic-ai/ui-components/assets/103023797/0f18a3ea-e4ed-4f08-a77c-8e1a621f3686)
![Screenshot 2024-04-04 at 11 41 26 PM](https://github.com/rustic-ai/ui-components/assets/103023797/b869e61e-fe99-4f5c-b2df-90720e79ac04)
![Screenshot 2024-04-04 at 11 41 32 PM](https://github.com/rustic-ai/ui-components/assets/103023797/af8e55b3-9a9f-4dea-8f44-7d8cac605353)
![Screenshot 2024-04-04 at 11 41 50 PM](https://github.com/rustic-ai/ui-components/assets/103023797/963b648d-962c-4117-9ba6-c1d3b440a39d)

