### PR TITLE
docs: update image props name in messageSpace

### DIFF
--- a/src/components/messageSpace/messageSpace.stories.tsx
+++ b/src/components/messageSpace/messageSpace.stories.tsx
@@ -279,7 +279,7 @@ export const Default = {
         timestamp: '2024-01-02T00:11:00.000Z',
         format: 'image',
         data: {
-          url: 'images/image-component-example.png',
+          src: 'images/image-component-example.png',
           alt: 'A curved facade covered in white latticework',
           description:
             'Lorem ipsum dolor sit amet consectetur. Aliquam vulputate sit non non tincidunt pellentesque varius euismod est. Lobortis feugiat euismod lorem viverra. Ipsum justo pellentesque.',


### PR DESCRIPTION
## Changes
- Update image component's props name in the MessageSpace story

## Before
<img width="984" alt="Screenshot 2024-04-05 at 9 53 03 AM" src="https://github.com/rustic-ai/ui-components/assets/103023797/361363b2-09e9-42dd-ae5f-c77d1ac3a322">

## After
<img width="973" alt="Screenshot 2024-04-05 at 9 52 17 AM" src="https://github.com/rustic-ai/ui-components/assets/103023797/ef963259-fe52-4983-b003-e8c0ae6c0197">
