### PR TITLE
feat(textInput): add speech-to-text functionality

### DIFF
--- a/global.d.ts
+++ b/global.d.ts
@@ -1,0 +1,6 @@
+declare global {
+  interface Window {
+    webkitSpeechRecognition: any
+    SpeechRecognition: any
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -48,6 +48,7 @@
         "@testing-library/cypress": "10.0.1",
         "@testing-library/react": "13.4.0",
         "@testing-library/user-event": "13.5.0",
+        "@types/dom-speech-recognition": "0.0.4",
         "@types/dompurify": "3.0.5",
         "@types/node": "20.11.20",
         "@types/pluralize": "0.0.33",
@@ -7109,6 +7110,12 @@
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/@types/doctrine/-/doctrine-0.0.3.tgz",
       "integrity": "sha512-w5jZ0ee+HaPOaX25X2/2oGR/7rgAQSYII7X7pp0m9KgBfMP7uKfMfTvcpl5Dj+eDBbpxKGiqE+flqDr6XTd2RA==",
+      "dev": true
+    },
+    "node_modules/@types/dom-speech-recognition": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/@types/dom-speech-recognition/-/dom-speech-recognition-0.0.4.tgz",
+      "integrity": "sha512-zf2GwV/G6TdaLwpLDcGTIkHnXf8JEf/viMux+khqKQKDa8/8BAUtXXZS563GnvJ4Fg0PBLGAaFf2GekEVSZ6GQ==",
       "dev": true
     },
     "node_modules/@types/dompurify": {

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "@testing-library/cypress": "10.0.1",
     "@testing-library/react": "13.4.0",
     "@testing-library/user-event": "13.5.0",
+    "@types/dom-speech-recognition": "0.0.4",
     "@types/dompurify": "3.0.5",
     "@types/node": "20.11.20",
     "@types/pluralize": "0.0.33",

--- a/src/components/textInput/textInput.css
+++ b/src/components/textInput/textInput.css
@@ -1,6 +1,6 @@
 .rustic-text-input-container {
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   gap: 8px;
 }
 

--- a/src/components/textInput/textInput.css
+++ b/src/components/textInput/textInput.css
@@ -1,9 +1,15 @@
 .rustic-text-input-container {
   display: flex;
-  align-items: flex-start;
+  align-items: flex-end;
   gap: 8px;
 }
 
 .rustic-text-input-container .rustic-text-input fieldset[aria-hidden='true'] {
   border-width: 1px;
+}
+
+.rustic-text-input-and-error-container {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
 }

--- a/src/components/textInput/textInput.cy.tsx
+++ b/src/components/textInput/textInput.cy.tsx
@@ -99,7 +99,7 @@ describe('TextInput', () => {
           conversationId="1"
           ws={mockWsClient}
           label="Type your message"
-          speechToText={true}
+          enableSpeechToText={true}
         />
       )
     })

--- a/src/components/textInput/textInput.cy.tsx
+++ b/src/components/textInput/textInput.cy.tsx
@@ -8,114 +8,138 @@ describe('TextInput', () => {
   const spaces = '     '
   const recordButton = '[data-cy=record-button]'
 
-  beforeEach(() => {
-    const mockWsClient = {
-      send: cy.stub(),
-      close: cy.stub(),
-      reconnect: cy.stub(),
-    }
+  context('Regular', () => {
+    beforeEach(() => {
+      const mockWsClient = {
+        send: cy.stub(),
+        close: cy.stub(),
+        reconnect: cy.stub(),
+      }
 
-    cy.window().then((win) => {
-      cy.stub(win, 'webkitSpeechRecognition').returns({
-        lang: 'en-US',
-        start: cy.stub().as('startStub'),
-        stop: cy.stub().as('stopStub'),
-        onerror: cy.stub().as('errorStub'),
-      })
+      cy.mount(
+        <TextInput
+          sender="client"
+          conversationId="1"
+          ws={mockWsClient}
+          label="Type your message"
+        />
+      )
     })
 
-    cy.mount(
-      <TextInput
-        sender="client"
-        conversationId="1"
-        ws={mockWsClient}
-        label="Type your message"
-        speechToText={true}
-      />
-    )
+    supportedViewports.forEach((viewport) => {
+      it(`should render the TextInput component on ${viewport} screen`, () => {
+        cy.viewport(viewport)
+        cy.get(textInput).should('exist')
+        cy.get(sendButton).should('exist')
+      })
+      it(`should have the send button enabled when the text input is not empty on ${viewport} screen`, () => {
+        cy.viewport(viewport)
+        cy.get(textInput).type(message)
+        cy.get(textInput).get('textarea').invoke('val').should('equal', message)
+        cy.get(sendButton).should('be.enabled')
+      })
+      it(`should have the send button disabled when the text input is empty on ${viewport} screen`, () => {
+        cy.viewport(viewport)
+        cy.get(textInput).find('textarea').invoke('val').should('equal', '')
+        cy.get(sendButton).should('be.disabled')
+      })
+      it(`should have the button disabled when the text input only contains spaces on ${viewport} screen`, () => {
+        cy.viewport(viewport)
+        cy.get(textInput).type(spaces)
+        cy.get(textInput).get('textarea').invoke('val').should('equal', spaces)
+        cy.get(sendButton).should('be.disabled')
+      })
+      it(`should not send the message when the text input only contains spaces and pressing enter on ${viewport} screen`, () => {
+        cy.viewport(viewport)
+        cy.get(textInput).type(spaces)
+        cy.get(textInput).find('textarea').invoke('val').should('equal', spaces)
+        cy.get(textInput).type('{enter}')
+        cy.get(textInput).find('textarea').invoke('val').should('equal', spaces)
+      })
+      it(`should have the button disabled when the text input only contains linebreaks (shift+enter) on ${viewport} screen`, () => {
+        cy.viewport(viewport)
+        cy.get(textInput).type('{shift}{enter}')
+        cy.get(textInput).find('textarea').invoke('val').should('equal', '\n')
+        cy.get(sendButton).should('be.disabled')
+      })
+      it(`should send the message when pressing enter on ${viewport} screen`, () => {
+        cy.viewport(viewport)
+        cy.get(textInput).type(message)
+        cy.get(textInput).get('textarea').invoke('val').should('equal', message)
+        cy.get(textInput).type('{enter}')
+        cy.get(textInput)
+          .get('textarea')
+          .first()
+          .invoke('val')
+          .should('equal', '')
+      })
+    })
   })
 
-  supportedViewports.forEach((viewport) => {
-    it(`should render the TextInput component on ${viewport} screen`, () => {
-      cy.viewport(viewport)
-      cy.get(textInput).should('exist')
-      cy.get(sendButton).should('exist')
-    })
-    it(`should have the send button enabled when the text input is not empty on ${viewport} screen`, () => {
-      cy.viewport(viewport)
-      cy.get(textInput).type(message)
-      cy.get(textInput).get('textarea').invoke('val').should('equal', message)
-      cy.get(sendButton).should('be.enabled')
-    })
-    it(`should have the send button disabled when the text input is empty on ${viewport} screen`, () => {
-      cy.viewport(viewport)
-      cy.get(textInput).find('textarea').invoke('val').should('equal', '')
-      cy.get(sendButton).should('be.disabled')
-    })
-    it(`should have the button disabled when the text input only contains spaces on ${viewport} screen`, () => {
-      cy.viewport(viewport)
-      cy.get(textInput).type(spaces)
-      cy.get(textInput).get('textarea').invoke('val').should('equal', spaces)
-      cy.get(sendButton).should('be.disabled')
-    })
-    it(`should not send the message when the text input only contains spaces and pressing enter on ${viewport} screen`, () => {
-      cy.viewport(viewport)
-      cy.get(textInput).type(spaces)
-      cy.get(textInput).find('textarea').invoke('val').should('equal', spaces)
-      cy.get(textInput).type('{enter}')
-      cy.get(textInput).find('textarea').invoke('val').should('equal', spaces)
-    })
-    it(`should have the button disabled when the text input only contains linebreaks (shift+enter) on ${viewport} screen`, () => {
-      cy.viewport(viewport)
-      cy.get(textInput).type('{shift}{enter}')
-      cy.get(textInput).find('textarea').invoke('val').should('equal', '\n')
-      cy.get(sendButton).should('be.disabled')
-    })
-    it(`should send the message when pressing enter on ${viewport} screen`, () => {
-      cy.viewport(viewport)
-      cy.get(textInput).type(message)
-      cy.get(textInput).get('textarea').invoke('val').should('equal', message)
-      cy.get(textInput).type('{enter}')
-      cy.get(textInput)
-        .get('textarea')
-        .first()
-        .invoke('val')
-        .should('equal', '')
-    })
-    it(`should start and stop speech recognition on ${viewport} screen`, () => {
-      cy.viewport(viewport)
-      // verify speech recognition has not started initially
-      cy.get(recordButton).click()
-
-      // verify speech recognition started
-      cy.get('@startStub').should('be.called')
-
-      cy.get(recordButton).click()
-      cy.get('@stopStub').should('be.called')
-      cy.get('[data-cy=spinner]').should('exist')
-      cy.window().then((win) => {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const recognition: any = new win.webkitSpeechRecognition()
-        recognition.onend()
-      })
-      cy.get('[data-cy=spinner]').should('not.exist')
-    })
-    it(`should add recorded results to text input on ${viewport} screen`, () => {
-      cy.viewport(viewport)
-
-      cy.get(recordButton).click()
-
-      const mockEvent = {
-        results: [[{ transcript: message }]],
+  context('Speech-to-text', () => {
+    beforeEach(() => {
+      const mockWsClient = {
+        send: cy.stub(),
+        close: cy.stub(),
+        reconnect: cy.stub(),
       }
 
       cy.window().then((win) => {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const recognition: any = new win.webkitSpeechRecognition()
-        recognition.onresult(mockEvent)
+        cy.stub(win, 'webkitSpeechRecognition').returns({
+          lang: 'en-US',
+          start: cy.stub().as('startStub'),
+          stop: cy.stub().as('stopStub'),
+          onerror: cy.stub().as('errorStub'),
+        })
       })
 
-      cy.get(`${textInput} textarea`).should('have.value', message)
+      cy.mount(
+        <TextInput
+          sender="client"
+          conversationId="1"
+          ws={mockWsClient}
+          label="Type your message"
+          speechToText={true}
+        />
+      )
+    })
+
+    supportedViewports.forEach((viewport) => {
+      it(`should start and stop speech recognition on ${viewport} screen`, () => {
+        cy.viewport(viewport)
+        // verify speech recognition has not started initially
+        cy.get(recordButton).click()
+
+        // verify speech recognition started
+        cy.get('@startStub').should('be.called')
+
+        cy.get(recordButton).click()
+        cy.get('@stopStub').should('be.called')
+        cy.get('[data-cy=spinner]').should('exist')
+        cy.window().then((win) => {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          const recognition: any = new win.webkitSpeechRecognition()
+          recognition.onend()
+        })
+        cy.get('[data-cy=spinner]').should('not.exist')
+      })
+      it(`should add recorded results to text input on ${viewport} screen`, () => {
+        cy.viewport(viewport)
+
+        cy.get(recordButton).click()
+
+        const mockEvent = {
+          results: [[{ transcript: message }]],
+        }
+
+        cy.window().then((win) => {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          const recognition: any = new win.webkitSpeechRecognition()
+          recognition.onresult(mockEvent)
+        })
+
+        cy.get(`${textInput} textarea`).should('have.value', message)
+      })
     })
   })
 })

--- a/src/components/textInput/textInput.cy.tsx
+++ b/src/components/textInput/textInput.cy.tsx
@@ -2,6 +2,12 @@ import { supportedViewports } from '../../../cypress/support/variables'
 import TextInput from './textInput'
 
 describe('TextInput', () => {
+  const textInput = '[data-cy=text-input]'
+  const sendButton = '[data-cy=send-button]'
+  const message = 'Hello, Cypress!'
+  const spaces = '     '
+  const recordButton = '[data-cy=record-button]'
+
   beforeEach(() => {
     const mockWsClient = {
       send: cy.stub(),
@@ -9,20 +15,25 @@ describe('TextInput', () => {
       reconnect: cy.stub(),
     }
 
+    cy.window().then((win) => {
+      cy.stub(win, 'webkitSpeechRecognition').returns({
+        lang: 'en-US',
+        start: cy.stub().as('startStub'),
+        stop: cy.stub().as('stopStub'),
+        onerror: cy.stub().as('errorStub'),
+      })
+    })
+
     cy.mount(
       <TextInput
         sender="client"
         conversationId="1"
         ws={mockWsClient}
-        label="Type you message"
+        label="Type your message"
+        speechToText={true}
       />
     )
   })
-
-  const textInput = '[data-cy=text-input]'
-  const sendButton = '[data-cy=send-button]'
-  const message = 'Hello, Cypress!'
-  const spaces = '     '
 
   supportedViewports.forEach((viewport) => {
     it(`should render the TextInput component on ${viewport} screen`, () => {
@@ -30,27 +41,23 @@ describe('TextInput', () => {
       cy.get(textInput).should('exist')
       cy.get(sendButton).should('exist')
     })
-
     it(`should have the send button enabled when the text input is not empty on ${viewport} screen`, () => {
       cy.viewport(viewport)
       cy.get(textInput).type(message)
       cy.get(textInput).get('textarea').invoke('val').should('equal', message)
       cy.get(sendButton).should('be.enabled')
     })
-
     it(`should have the send button disabled when the text input is empty on ${viewport} screen`, () => {
       cy.viewport(viewport)
       cy.get(textInput).find('textarea').invoke('val').should('equal', '')
       cy.get(sendButton).should('be.disabled')
     })
-
     it(`should have the button disabled when the text input only contains spaces on ${viewport} screen`, () => {
       cy.viewport(viewport)
       cy.get(textInput).type(spaces)
       cy.get(textInput).get('textarea').invoke('val').should('equal', spaces)
       cy.get(sendButton).should('be.disabled')
     })
-
     it(`should not send the message when the text input only contains spaces and pressing enter on ${viewport} screen`, () => {
       cy.viewport(viewport)
       cy.get(textInput).type(spaces)
@@ -58,14 +65,12 @@ describe('TextInput', () => {
       cy.get(textInput).type('{enter}')
       cy.get(textInput).find('textarea').invoke('val').should('equal', spaces)
     })
-
     it(`should have the button disabled when the text input only contains linebreaks (shift+enter) on ${viewport} screen`, () => {
       cy.viewport(viewport)
       cy.get(textInput).type('{shift}{enter}')
       cy.get(textInput).find('textarea').invoke('val').should('equal', '\n')
       cy.get(sendButton).should('be.disabled')
     })
-
     it(`should send the message when pressing enter on ${viewport} screen`, () => {
       cy.viewport(viewport)
       cy.get(textInput).type(message)
@@ -76,6 +81,41 @@ describe('TextInput', () => {
         .first()
         .invoke('val')
         .should('equal', '')
+    })
+    it(`should start and stop speech recognition on ${viewport} screen`, () => {
+      cy.viewport(viewport)
+      // verify speech recognition has not started initially
+      cy.get(recordButton).click()
+
+      // verify speech recognition started
+      cy.get('@startStub').should('be.called')
+
+      cy.get(recordButton).click()
+      cy.get('@stopStub').should('be.called')
+      cy.get('[data-cy=spinner]').should('exist')
+      cy.window().then((win) => {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const recognition: any = new win.webkitSpeechRecognition()
+        recognition.onend()
+      })
+      cy.get('[data-cy=spinner]').should('not.exist')
+    })
+    it(`should add recorded results to text input on ${viewport} screen`, () => {
+      cy.viewport(viewport)
+
+      cy.get(recordButton).click()
+
+      const mockEvent = {
+        results: [[{ transcript: message }]],
+      }
+
+      cy.window().then((win) => {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const recognition: any = new win.webkitSpeechRecognition()
+        recognition.onresult(mockEvent)
+      })
+
+      cy.get(`${textInput} textarea`).should('have.value', message)
     })
   })
 })

--- a/src/components/textInput/textInput.stories.tsx
+++ b/src/components/textInput/textInput.stories.tsx
@@ -42,7 +42,7 @@ export const Default = {
 export const SpeechToText = {
   args: {
     ...Default.args,
-    speechToText: true,
+    enableSpeechToText: true,
   },
 }
 

--- a/src/components/textInput/textInput.stories.tsx
+++ b/src/components/textInput/textInput.stories.tsx
@@ -29,6 +29,12 @@ export const Default = {
   },
 }
 
+export const SpeechToText = {
+  args: {
+    ...Default.args,
+    speechToText: true,
+  },
+}
 export const NoMultiLine = {
   args: {
     ...Default.args,

--- a/src/components/textInput/textInput.stories.tsx
+++ b/src/components/textInput/textInput.stories.tsx
@@ -1,3 +1,6 @@
+import type { StoryFn } from '@storybook/react'
+import React from 'react'
+
 import TextInput from './textInput'
 
 export default {
@@ -19,6 +22,13 @@ export default {
       },
     },
   },
+  decorators: [
+    (Story: StoryFn) => (
+      <div style={{ width: 'clamp(250px, 25vw, 500px)' }}>
+        <Story />
+      </div>
+    ),
+  ],
 }
 
 export const Default = {
@@ -35,6 +45,7 @@ export const SpeechToText = {
     speechToText: true,
   },
 }
+
 export const NoMultiLine = {
   args: {
     ...Default.args,

--- a/src/components/textInput/textInput.tsx
+++ b/src/components/textInput/textInput.tsx
@@ -7,7 +7,7 @@ import InputAdornment from '@mui/material/InputAdornment'
 import TextField from '@mui/material/TextField'
 import Tooltip from '@mui/material/Tooltip'
 import Typography from '@mui/material/Typography'
-import { useState } from 'react'
+import { useRef, useState } from 'react'
 import React from 'react'
 import { v4 as getUUID } from 'uuid'
 
@@ -40,6 +40,8 @@ export default function TextInput(props: TextInputProps) {
   const [isFocused, setIsFocused] = useState(false)
   const [isEndingRecording, setIsEndingRecording] = useState(false)
 
+  const inputRef = useRef<HTMLInputElement>(null)
+
   const isEmptyMessage = !messageText.trim().length
   const speechToTextTooltipTitle = `${isRecording ? 'Stop' : 'Start'} speech to text`
   const speechToTextInactiveColor = isFocused ? 'primary.main' : 'primary.light'
@@ -49,17 +51,22 @@ export default function TextInput(props: TextInputProps) {
   const speechToTextIconName = isRecording ? 'stop_circle' : 'speech_to_text'
 
   const speechRecognitionErrors = {
-    'no-speech': 'no speech was detected',
-    aborted: 'speech input was aborted, possibly due to user action',
-    'audio-capture': 'audio capture failed',
-    network: 'network communication required for recognition failed',
+    'no-speech':
+      'No speech detected. Check your microphone volume and try again.',
+    aborted:
+      'Speech input was aborted. Ensure no other windows are accessing your microphone and try again.',
+    'audio-capture':
+      'Could not capture any audio. Check that your microphone is connected and try again.',
+    network:
+      'Failed to connect to the internet for recognition. Check your internet connection and try again.',
     'not-allowed':
-      'speech input disallowed due to security, privacy, or user preference',
+      'This functionality requires microphone access. Please allow microphone access and try again.',
     'service-not-allowed':
-      'requested speech recognition service not allowed by user agent',
-    'bad-grammar': 'error in speech recognition grammar or unsupported format',
+      "Speech recognition service is not allowed, either because the browser doesn't support it or because of reasons of security, privacy or user preference.",
+    'bad-grammar':
+      'There was an error in the speech recognition grammar or format. Check your speech input or grammar rules.',
     'language-not-supported':
-      'user agent does not support the specified language for recognition',
+      "The language you're speaking isn't supported. Try speaking in a different language or check your device settings.",
   }
 
   const speechToTextButtonAdornment = {
@@ -114,13 +121,14 @@ export default function TextInput(props: TextInputProps) {
         setMessageText(currentTranscript)
       }
 
+      inputRef.current?.focus()
       setIsRecording(false)
     }
 
     microphone.onerror = (event: SpeechRecognitionErrorEvent) => {
       const errorDescription = speechRecognitionErrors[event.error]
 
-      setErrorMessage(`An error occurred: ${errorDescription}.`)
+      setErrorMessage(errorDescription)
       setIsRecording(false)
     }
 
@@ -186,6 +194,7 @@ export default function TextInput(props: TextInputProps) {
           onChange={handleOnChange}
           onFocus={() => setIsFocused(true)}
           onBlur={() => setIsFocused(false)}
+          inputRef={inputRef}
           color="secondary"
           size="small"
           error={!!errorMessage}

--- a/src/components/textInput/textInput.tsx
+++ b/src/components/textInput/textInput.tsx
@@ -61,18 +61,6 @@ export default function TextInput(props: TextInputProps) {
       'user agent does not support the specified language for recognition',
   }
 
-  function renderSpeechToTextIcon() {
-    return (
-      <>
-        {isRecording ? (
-          <span className="material-symbols-rounded">mic_off</span>
-        ) : (
-          <span className="material-symbols-rounded">mic</span>
-        )}
-      </>
-    )
-  }
-
   const speechToTextButtonAdornment = {
     endAdornment: (
       <InputAdornment position="end">
@@ -86,7 +74,7 @@ export default function TextInput(props: TextInputProps) {
               size="small"
               sx={{ color: speechToTextIconColor }}
             >
-              {renderSpeechToTextIcon()}
+              <span className="material-symbols-rounded">speech_to_text</span>
             </IconButton>
           </Tooltip>
         )}

--- a/src/components/textInput/textInput.tsx
+++ b/src/components/textInput/textInput.tsx
@@ -44,8 +44,9 @@ export default function TextInput(props: TextInputProps) {
   const speechToTextTooltipTitle = `${isRecording ? 'Stop' : 'Start'} speech to text`
   const speechToTextInactiveColor = isFocused ? 'primary.main' : 'primary.light'
   const speechToTextIconColor = isRecording
-    ? 'secondary.main'
+    ? 'error.main'
     : speechToTextInactiveColor
+  const speechToTextIconName = isRecording ? 'stop_circle' : 'speech_to_text'
 
   const speechRecognitionErrors = {
     'no-speech': 'no speech was detected',
@@ -74,7 +75,9 @@ export default function TextInput(props: TextInputProps) {
               size="small"
               sx={{ color: speechToTextIconColor }}
             >
-              <span className="material-symbols-rounded">speech_to_text</span>
+              <span className="material-symbols-rounded">
+                {speechToTextIconName}
+              </span>
             </IconButton>
           </Tooltip>
         )}

--- a/src/components/textInput/textInput.tsx
+++ b/src/components/textInput/textInput.tsx
@@ -1,7 +1,5 @@
 import './textInput.css'
 
-import MicNoneRoundedIcon from '@mui/icons-material/MicNoneRounded'
-import MicRoundedIcon from '@mui/icons-material/MicRounded'
 import Box from '@mui/material/Box'
 import CircularProgress from '@mui/material/CircularProgress'
 import IconButton from '@mui/material/IconButton'
@@ -44,7 +42,10 @@ export default function TextInput(props: TextInputProps) {
 
   const isEmptyMessage = !messageText.trim().length
   const speechToTextTooltipTitle = `${isRecording ? 'Stop' : 'Start'} speech to text`
-  const speechToTextIconColor = isFocused ? 'primary.main' : 'primary.light'
+  const speechToTextInactiveColor = isFocused ? 'primary.main' : 'primary.light'
+  const speechToTextIconColor = isRecording
+    ? 'secondary.main'
+    : speechToTextInactiveColor
 
   const speechRecognitionErrors = {
     'no-speech': 'no speech was detected',
@@ -64,13 +65,9 @@ export default function TextInput(props: TextInputProps) {
     return (
       <>
         {isRecording ? (
-          <MicRoundedIcon color="secondary" />
+          <span className="material-symbols-rounded">mic_off</span>
         ) : (
-          <MicNoneRoundedIcon
-            sx={{
-              color: speechToTextIconColor,
-            }}
-          />
+          <span className="material-symbols-rounded">mic</span>
         )}
       </>
     )
@@ -87,6 +84,7 @@ export default function TextInput(props: TextInputProps) {
               data-cy="record-button"
               onClick={handleToggleSpeechToText}
               size="small"
+              sx={{ color: speechToTextIconColor }}
             >
               {renderSpeechToTextIcon()}
             </IconButton>
@@ -171,10 +169,6 @@ export default function TextInput(props: TextInputProps) {
     setMessageText(e.target.value)
   }
 
-  function handleOnFocusToggle() {
-    setIsFocused(!isFocused)
-  }
-
   return (
     <Box className="rustic-text-input-container">
       <Box className="rustic-text-input-and-error-container">
@@ -199,8 +193,8 @@ export default function TextInput(props: TextInputProps) {
           fullWidth={props.fullWidth}
           onKeyDown={handleKeyDown}
           onChange={handleOnChange}
-          onFocus={handleOnFocusToggle}
-          onBlur={handleOnFocusToggle}
+          onFocus={() => setIsFocused(true)}
+          onBlur={() => setIsFocused(false)}
           color="secondary"
           size="small"
           error={!!errorMessage}

--- a/src/components/textInput/textInput.tsx
+++ b/src/components/textInput/textInput.tsx
@@ -29,8 +29,8 @@ export interface TextInputProps {
   maxRows?: number
   /** Boolean that dictates whether `TextInput` takes up 100% width of the parent container. */
   fullWidth?: boolean
-  /** Boolean to allow option for speech-to-text. See which browsers are supported [here](https://developer.mozilla.org/en-US/docs/Web/API/SpeechRecognition#browser_compatibility). */
-  speechToText?: boolean
+  /** Boolean to enable speech-to-text. See which browsers are supported [here](https://developer.mozilla.org/en-US/docs/Web/API/SpeechRecognition#browser_compatibility). */
+  enableSpeechToText?: boolean
 }
 
 export default function TextInput(props: TextInputProps) {
@@ -189,7 +189,9 @@ export default function TextInput(props: TextInputProps) {
           color="secondary"
           size="small"
           error={!!errorMessage}
-          InputProps={props.speechToText ? speechToTextButtonAdornment : {}}
+          InputProps={
+            props.enableSpeechToText ? speechToTextButtonAdornment : {}
+          }
         />
       </Box>
       <IconButton
@@ -209,4 +211,5 @@ TextInput.defaultProps = {
   multiline: true,
   fullWidth: true,
   maxRows: 6,
+  enableSpeechToText: false,
 }

--- a/src/components/textInput/textInput.tsx
+++ b/src/components/textInput/textInput.tsx
@@ -1,9 +1,14 @@
 import './textInput.css'
 
+import MicNoneRoundedIcon from '@mui/icons-material/MicNoneRounded'
+import MicRoundedIcon from '@mui/icons-material/MicRounded'
 import SendIcon from '@mui/icons-material/Send'
 import Box from '@mui/material/Box'
+import CircularProgress from '@mui/material/CircularProgress'
 import IconButton from '@mui/material/IconButton'
+import InputAdornment from '@mui/material/InputAdornment'
 import TextField from '@mui/material/TextField'
+import Tooltip from '@mui/material/Tooltip'
 import { useState } from 'react'
 import React from 'react'
 import { v4 as getUUID } from 'uuid'
@@ -26,10 +31,15 @@ export interface TextInputProps {
   maxRows?: number
   /** Boolean that dictates whether `TextInput` takes up 100% width of the parent container. */
   fullWidth?: boolean
+  /** Boolean to allow option for speech-to-text. See which browsers are supported [here](https://developer.mozilla.org/en-US/docs/Web/API/SpeechRecognition#browser_compatibility). */
+  speechToText?: boolean
 }
 
 export default function TextInput(props: TextInputProps) {
   const [messageText, setMessageText] = useState<string>('')
+  const [isRecording, setIsRecording] = useState(false)
+  const [isFocused, setIsFocused] = useState(false)
+  const [isEndingRecording, setIsEndingRecording] = useState(false)
 
   const isEmptyMessage = !messageText.trim().length
 
@@ -62,6 +72,81 @@ export default function TextInput(props: TextInputProps) {
     setMessageText(e.target.value)
   }
 
+  function handleOnFocusToggle() {
+    setIsFocused(!isFocused)
+  }
+
+  function handleToggleSpeechToText() {
+    const microphone = new window.webkitSpeechRecognition()
+
+    microphone.lang = 'en-US'
+
+    if (isRecording) {
+      microphone.stop()
+      setIsEndingRecording(true)
+      setIsRecording(false)
+    } else {
+      microphone.start()
+      setIsRecording(true)
+    }
+
+    microphone.onstart = () => {
+      setIsRecording(true)
+    }
+
+    microphone.onresult = (event: SpeechRecognitionEvent) => {
+      // eslint-disable-next-line no-console
+      console.log('onresult happened')
+      const currentTranscript = event.results[0][0].transcript
+
+      if (messageText.length > 0) {
+        setMessageText(messageText + ' ' + currentTranscript)
+      } else {
+        setMessageText(currentTranscript)
+      }
+
+      setIsRecording(false)
+    }
+
+    microphone.onerror = (event: SpeechRecognitionErrorEvent) => {
+      console.error('Speech recognition error:', event.error)
+      setIsRecording(false)
+    }
+
+    microphone.onend = () => {
+      setIsEndingRecording(false)
+      setIsRecording(false)
+    }
+  }
+
+  const speechToTextButtonAdornment = {
+    endAdornment: (
+      <InputAdornment position="end">
+        {isEndingRecording ? (
+          <CircularProgress size={24} data-cy="spinner" />
+        ) : (
+          <Tooltip title={`${isRecording ? 'Stop' : 'Start'} speech to text`}>
+            <IconButton
+              data-cy="record-button"
+              onClick={handleToggleSpeechToText}
+              size="small"
+            >
+              {isRecording ? (
+                <MicRoundedIcon color="secondary" />
+              ) : (
+                <MicNoneRoundedIcon
+                  sx={{
+                    color: isFocused ? 'primary.main' : 'primary.light',
+                  }}
+                />
+              )}
+            </IconButton>
+          </Tooltip>
+        )}
+      </InputAdornment>
+    ),
+  }
+
   return (
     <Box className="rustic-text-input-container">
       <TextField
@@ -76,8 +161,11 @@ export default function TextInput(props: TextInputProps) {
         fullWidth={props.fullWidth}
         onKeyDown={handleKeyDown}
         onChange={handleOnChange}
+        onFocus={handleOnFocusToggle}
+        onBlur={handleOnFocusToggle}
         color="secondary"
         size="small"
+        InputProps={props.speechToText ? speechToTextButtonAdornment : {}}
       />
       <IconButton
         data-cy="send-button"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,11 +2,7 @@
   "compilerOptions": {
     "target": "es5",
     "outDir": "dist",
-    "lib": [
-      "dom",
-      "dom.iterable",
-      "esnext"
-    ],
+    "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,
     "esModuleInterop": true,
@@ -21,12 +17,13 @@
     "noEmit": false,
     "jsx": "react-jsx",
     "verbatimModuleSyntax": true,
-    "types": ["cypress-real-events"]
+    "types": ["cypress-real-events", "dom-speech-recognition"]
   },
   "include": [
     "src",
     "cypress",
     "./cypress.d.ts",
-    "cypress.config.ts"
+    "cypress.config.ts",
+    "global.d.ts"
   ]
 }


### PR DESCRIPTION
## Changes
- add speech-to-text functionality to the `TextInput` component

## Screenshots
### Design
<img width="818" alt="Screenshot 2024-04-05 at 2 55 31 PM" src="https://github.com/rustic-ai/ui-components/assets/111031789/2a2c5898-7886-4d35-a7eb-04a435b894ac">

### New prop
<img width="580" alt="Screenshot 2024-04-21 at 2 33 52 PM" src="https://github.com/rustic-ai/ui-components/assets/111031789/7f5a3f8d-1269-43bc-9455-a44f1084408f">

### Text input unfocused
<img width="357" alt="Screenshot 2024-04-19 at 12 37 13 PM" src="https://github.com/rustic-ai/ui-components/assets/111031789/32754481-1711-4f77-91bd-83f34703534b">

### Text input focused
<img width="357" alt="Screenshot 2024-04-19 at 12 37 19 PM" src="https://github.com/rustic-ai/ui-components/assets/111031789/f8ca4d26-4c1a-4147-bb06-0ecf6366ebe8">

### Button hover
<img width="357" alt="Screenshot 2024-04-19 at 12 37 24 PM" src="https://github.com/rustic-ai/ui-components/assets/111031789/5bec162a-e869-4b03-ad3b-0c175f4c7537">

### Recording
<img width="357" alt="Screenshot 2024-04-19 at 2 34 37 PM" src="https://github.com/rustic-ai/ui-components/assets/111031789/5bb0a5f9-9733-4590-9645-0842c93f7568">

### Process recording
<img width="357" alt="Screenshot 2024-04-19 at 12 39 57 PM" src="https://github.com/rustic-ai/ui-components/assets/111031789/06850902-1691-4b76-b52e-71e8828bf087">

#### Error
<img width="339" alt="Screenshot 2024-04-21 at 2 32 53 PM" src="https://github.com/rustic-ai/ui-components/assets/111031789/1667e761-0b86-4566-963b-df8cccb971eb">

### Interaction
#### Stop recording automatically when speech ends
![stop-auto](https://github.com/rustic-ai/ui-components/assets/111031789/e33f8eea-bd49-4d0d-bb20-46f32e2b6d6c)

#### Stop recording manually when clicking button again
![stop-manual](https://github.com/rustic-ai/ui-components/assets/111031789/5e0bd012-81c8-462d-bd45-d221013d1c1f)

### Dark Mode
![dark](https://github.com/rustic-ai/ui-components/assets/111031789/67057f6a-b9b7-40a3-8d9d-7617728f0134)
