### PR TITLE
docs: update quick start doc

### DIFF
--- a/docs/quickStart.stories.mdx
+++ b/docs/quickStart.stories.mdx
@@ -24,10 +24,21 @@ Follow these steps to quickly integrate Rustic UI Components into your applicati
    @import '@rustic-ai/ui-components/dist/index.css';
    ```
 
-3. Start integrating Rustic UI Components into your application by importing the necessary components. Below is a sample code snippet demonstrating how to use the MessageSpace component to render messages:
+3. Rustic UI Components use [Material Symbols](https://fonts.google.com/icons) icons. To ensure the icons are displayed correctly, add the following to the `<head>` of your `index.html` file:
+
+   ```
+    <link
+     rel="stylesheet"
+     href="https://fonts.googleapis.com/css2?family=Material+Symbols+Rounded:opsz,wght,FILL,GRAD@24,400,1,0"
+    />
+
+   ```
+
+4. Start integrating Rustic UI Components into your application by importing the necessary components. Below is a sample code snippet demonstrating how to use the MessageSpace component to render messages:
 
    ```
    import {
+     CodeSnippet
      FCCalendar,
      Image,
      MarkedMarkdown,
@@ -35,6 +46,7 @@ Follow these steps to quickly integrate Rustic UI Components into your applicati
      MessageSpace,
      OpenLayersMap,
      RechartsTimeSeries,
+     Sound,
      StreamingText,
      Table,
      Text,
@@ -60,6 +72,8 @@ Follow these steps to quickly integrate Rustic UI Components into your applicati
                    youtubeVideo: YoutubeVideo,
                    table: Table,
                    calendar: FCCalendar,
+                   codeSnippet: CodeSnippet,
+                   audio: Sound
                }}
                // Include other components as needed
                />


### PR DESCRIPTION
## Changes
- add section about using Material Symbols
- add new components to `supportElements` example in step 4

## Screenshots
### Before
<img width="524" alt="Screenshot 2024-04-06 at 4 10 25 PM" src="https://github.com/rustic-ai/ui-components/assets/111031789/c3f42b7a-5ed1-4ee4-be0e-aa0c9afdedad">
<img width="524" alt="Screenshot 2024-04-06 at 4 10 40 PM" src="https://github.com/rustic-ai/ui-components/assets/111031789/643655cd-3aed-4fb4-8e4f-5b5c5b6da93d">

### After
<img width="524" alt="Screenshot 2024-04-06 at 4 06 45 PM" src="https://github.com/rustic-ai/ui-components/assets/111031789/07630f28-24dd-4bdb-b4ad-ad07ae26d84e">
<img width="524" alt="Screenshot 2024-04-06 at 4 07 02 PM" src="https://github.com/rustic-ai/ui-components/assets/111031789/83f89a37-3830-4120-a936-49e32b6a87fa">