### PR TITLE
fix: tooltip and axis colors in time series

### DIFF
--- a/src/components/chart/rechartsTimeSeries.tsx
+++ b/src/components/chart/rechartsTimeSeries.tsx
@@ -8,6 +8,7 @@ import Menu from '@mui/material/Menu'
 import MenuItem from '@mui/material/MenuItem'
 import Typography from '@mui/material/Typography'
 import Box from '@mui/system/Box'
+import useTheme from '@mui/system/useTheme'
 import { Fragment, useEffect, useState } from 'react'
 import React from 'react'
 import {
@@ -113,7 +114,7 @@ function RechartsTimeSeries(props: RechartsTimeSeriesProps) {
   )
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null)
   const [timeSeries, setTimeSeries] = useState<object[]>(props.timeSeries)
-
+  const theme = useTheme()
   const dataFields = timeSeries.length > 0 ? Object.keys(timeSeries[0]) : []
   const xAxisField = dataFields[0]
   const yAxisFields = dataFields.slice(1)
@@ -370,17 +371,22 @@ function RechartsTimeSeries(props: RechartsTimeSeriesProps) {
                 tickFormatter={(value) =>
                   formatTimestampLabel(value, timeSeriesDuration)
                 }
+                stroke={theme.palette.text.primary}
               />
               <YAxis
                 domain={['auto', 'auto']}
                 width={props.yAxisLabelWidth}
                 tickFormatter={props.yAxisTickFormatter}
+                stroke={theme.palette.text.primary}
               />
               <Tooltip
                 labelFormatter={(label: number) => [
                   formatTimestampLabel(label, timeSeriesDuration),
                 ]}
                 formatter={props.tooltipFormatter}
+                contentStyle={{
+                  color: theme.palette.common.black,
+                }}
               />
               <Legend content={renderLegend} />
 


### PR DESCRIPTION
## Changes
- Update tooltip and axis colors in time series (Tooltip was not shown properly and axes color didn't have enough contrast with the background color in the dark theme)

## Before
<img width="645" alt="Screenshot 2024-04-09 at 1 48 24 PM" src="https://github.com/rustic-ai/ui-components/assets/103023797/aeb505db-9a31-4351-b492-7d470ee1aee4">
<img width="680" alt="Screenshot 2024-04-09 at 1 48 13 PM" src="https://github.com/rustic-ai/ui-components/assets/103023797/199fdbc7-9480-4f80-a16d-2742709f51dd">

## After
<img width="896" alt="Screenshot 2024-04-09 at 1 43 50 PM" src="https://github.com/rustic-ai/ui-components/assets/103023797/bec077bf-029d-440c-89c5-2558d54f78f4">
<img width="890" alt="Screenshot 2024-04-09 at 1 44 00 PM" src="https://github.com/rustic-ai/ui-components/assets/103023797/f41a7c90-3823-4e5c-aea2-da54ee405fa9">
