### PR TITLE
docs: remove unnecessary config

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,4 +1,4 @@
-import { DEFAULT_VIEWPORT, INITIAL_VIEWPORTS } from '@storybook/addon-viewport'
+import { INITIAL_VIEWPORTS } from '@storybook/addon-viewport'
 import { CssBaseline, ThemeProvider } from '@mui/material'
 import { StyledEngineProvider } from '@mui/material/styles'
 import {
@@ -38,7 +38,6 @@ const preview = {
     actions: { argTypesRegex: '^on[A-Z].*' },
     viewport: {
       viewports: INITIAL_VIEWPORTS,
-      defaultViewport: DEFAULT_VIEWPORT,
     },
     controls: { expanded: true },
     docs: {


### PR DESCRIPTION
## Change
- Had a warning on storybook before (See below). Fixed by removing the unnecessary default theme config. Change `defaultViewport: DEFAULT_VIEWPORT,` to `...DEFAULT_VIEWPORT,` would also fixed the problem, but `responsive` is the default value for `defaultViewport` so there's no need to set it again. Reference: https://storybook.js.org/docs/essentials/viewport

## Before
<img width="507" alt="Screenshot 2024-04-11 at 11 36 03 AM" src="https://github.com/rustic-ai/ui-components/assets/103023797/ab2f1e83-e776-4d41-8fa5-29236e228fc6">

