### PR TITLE
feat(sound): make play pause button bigger on mobile

### DIFF
--- a/src/components/media/audio/sound.css
+++ b/src/components/media/audio/sound.css
@@ -45,4 +45,8 @@
     flex-direction: column;
     padding-inline: 0;
   }
+
+  .rustic-sound .rustic-pause-play-icon span {
+    font-size: 52px;
+  }
 }


### PR DESCRIPTION
## Changes
- make play pause button bigger on mobile

## Design
<img width="769" alt="Screenshot 2024-04-13 at 10 27 44 AM" src="https://github.com/rustic-ai/ui-components/assets/111031789/703b566d-b493-4c35-ac80-6fb8f0287475">

## Before
<img width="424" alt="Screenshot 2024-04-13 at 10 27 10 AM" src="https://github.com/rustic-ai/ui-components/assets/111031789/ef60f9cf-40cd-4df9-9e14-f50a5dcfb828">

## After
<img width="455" alt="Screenshot 2024-04-13 at 10 26 37 AM" src="https://github.com/rustic-ai/ui-components/assets/111031789/435c66b7-e3ec-4b6c-adfa-e531cfa436b9">
