### PR TITLE
fix: exit fullscreen bug when pressing esc

### DIFF
--- a/src/components/media/controls/videoControls.tsx
+++ b/src/components/media/controls/videoControls.tsx
@@ -60,6 +60,8 @@ export function PictureInPictureButton(props: PictureInPictureButtonProps) {
 export function FullscreenButton(props: FullscreenButtonProps) {
   const [isFullscreen, setIsFullscreen] = useState(!!document.fullscreenElement)
 
+  const videoContainer = props.element
+
   const action = isFullscreen ? 'fullscreenExit' : 'fullscreen'
 
   function handleFullscreen() {
@@ -75,7 +77,7 @@ export function FullscreenButton(props: FullscreenButtonProps) {
           )
         })
     } else {
-      props.element
+      videoContainer
         .requestFullscreen()
         .then(() => {
           setIsFullscreen(true)
@@ -86,6 +88,11 @@ export function FullscreenButton(props: FullscreenButtonProps) {
           )
         })
     }
+  }
+
+  // State is updated by event listeners so that the icon is displayed correctly, even when fullscreen is exited without direct use of this toggle (e.g. exiting from fullscreen by pressing Esc).
+  videoContainer.onfullscreenchange = function () {
+    setIsFullscreen(!!document.fullscreenElement)
   }
 
   return <MediaIconButton onClick={handleFullscreen} action={action} />


### PR DESCRIPTION
## Changes
- fix bug regarding attempting to enter fullscreen after exiting fullscreen with `esc`

*To be rebased and merged after PR #80 

## Before
<img width="925" alt="Screenshot 2024-04-16 at 2 32 38 PM" src="https://github.com/rustic-ai/ui-components/assets/111031789/8f651f94-6561-4b02-8e46-12f5b0be0151">