### PR TITLE
feat: add tooltip to media control buttons

### DIFF
--- a/src/components/media/controls/commonControls.tsx
+++ b/src/components/media/controls/commonControls.tsx
@@ -6,6 +6,7 @@ import Box from '@mui/material/Box'
 import Button from '@mui/material/Button'
 import LinearProgress from '@mui/material/LinearProgress'
 import Slider from '@mui/material/Slider'
+import Tooltip from '@mui/material/Tooltip'
 import Typography from '@mui/material/Typography'
 import React, { useState } from 'react'
 
@@ -214,14 +215,20 @@ export function PlaybackRateButton(props: MediaControls) {
   }
 
   return (
-    <Button
-      onClick={handlePlaybackRateChange}
-      className="rustic-playback-rate-button"
-      aria-label={`Playback rate: ${playbackRate}x, click to change`}
-      data-cy="playback-rate-button"
+    <Tooltip
+      title="playback rate"
+      PopperProps={{
+        container: document.fullscreenElement ?? document.body,
+      }}
     >
-      <Typography variant="body1">{playbackRate}X</Typography>
-    </Button>
+      <Button
+        onClick={handlePlaybackRateChange}
+        className="rustic-playback-rate-button"
+        data-cy="playback-rate-button"
+      >
+        <Typography variant="body1">{playbackRate}X</Typography>
+      </Button>
+    </Tooltip>
   )
 }
 

--- a/src/components/media/controls/mediaIconButton.tsx
+++ b/src/components/media/controls/mediaIconButton.tsx
@@ -1,5 +1,6 @@
 import Icon from '@mui/material/Icon'
 import IconButton from '@mui/material/IconButton'
+import Tooltip from '@mui/material/Tooltip'
 import React from 'react'
 
 interface MediaIconButtonProps {
@@ -45,17 +46,21 @@ export function MediaIconButton(props: MediaIconButtonProps) {
   const dataCyPrefix = controls[props.action].label.replaceAll(' ', '-')
 
   return (
-    <IconButton
-      onClick={props.onClick}
-      aria-label={`click to ${controls[props.action].label}`}
-      className={props.className}
-      data-cy={`${dataCyPrefix}-button`}
+    <Tooltip
+      title={controls[props.action].label}
+      PopperProps={{ container: document.fullscreenElement ?? document.body }}
     >
-      <Icon color="primary">
-        <span className="material-symbols-rounded">
-          {controls[props.action].symbol}
-        </span>
-      </Icon>
-    </IconButton>
+      <IconButton
+        onClick={props.onClick}
+        className={props.className}
+        data-cy={`${dataCyPrefix}-button`}
+      >
+        <Icon color="primary">
+          <span className="material-symbols-rounded">
+            {controls[props.action].symbol}
+          </span>
+        </Icon>
+      </IconButton>
+    </Tooltip>
   )
 }


### PR DESCRIPTION
## Changes
- add tooltip to media control buttons

## Screenshots
### Before
<img width="129" alt="Screenshot 2024-04-17 at 4 20 33 PM" src="https://github.com/rustic-ai/ui-components/assets/111031789/398a1cae-3fb5-448f-b082-78f497c5c35c">

### After
<img width="129" alt="Screenshot 2024-04-17 at 4 19 52 PM" src="https://github.com/rustic-ai/ui-components/assets/111031789/45731dc4-ecbb-4c21-918d-2e13cc83538a">
