### PR TITLE
docs(video): update storybook

### DIFF
--- a/src/components/media/video/video.stories.tsx
+++ b/src/components/media/video/video.stories.tsx
@@ -8,6 +8,7 @@ export default {
   component: Video,
   tags: ['autodocs'],
   parameters: {
+    layout: 'centered',
     docs: {
       description: {
         component:
@@ -15,6 +16,15 @@ export default {
       },
     },
   },
+  decorators: [
+    (Story: StoryFn) => {
+      return (
+        <div style={{ maxWidth: '750px' }}>
+          <Story />
+        </div>
+      )
+    },
+  ],
 }
 
 const videoSrc = 'videoExamples/videoStorybook.mp4'
@@ -40,13 +50,10 @@ export const WithCaptions = {
     title: 'Sound with Captions',
     captions: 'audioExamples/captions.vtt',
   },
-  parameters: {
-    layout: 'centered',
-  },
   decorators: [
     (Story: StoryFn) => {
       return (
-        <div style={{ width: '500px' }}>
+        <div style={{ maxWidth: '500px' }}>
           <Story />
         </div>
       )


### PR DESCRIPTION
## Changes
- add max width to stories so they don't take up large screen width when viewing individually
- change captions width to max width

## Screenshots
### Before
<img width="1507" alt="Screenshot 2024-04-20 at 11 59 41 AM" src="https://github.com/rustic-ai/ui-components/assets/111031789/552ba66b-976e-47e3-a5a2-5133d8ebc9a0">

### After
<img width="1509" alt="Screenshot 2024-04-22 at 10 23 06 AM" src="https://github.com/rustic-ai/ui-components/assets/111031789/cd12b93c-2738-4649-acb0-d9e65c7fa429">

