### PR TITLE
fix: replace mui icons with material symbols

### DIFF
--- a/docs/quickStart.stories.mdx
+++ b/docs/quickStart.stories.mdx
@@ -27,11 +27,10 @@ Follow these steps to quickly integrate Rustic UI Components into your applicati
 3. Rustic UI Components use [Material Symbols](https://fonts.google.com/icons) icons. To ensure the icons are displayed correctly, add the following to the `<head>` of your `index.html` file:
 
    ```
-    <link
-     rel="stylesheet"
-     href="https://fonts.googleapis.com/css2?family=Material+Symbols+Rounded:opsz,wght,FILL,GRAD@24,400,1,0"
-    />
-
+   <link
+    rel="stylesheet"
+    href="https://fonts.googleapis.com/css2?family=Material+Symbols+Rounded:opsz,wght,FILL,GRAD@24,400,1,0"
+   />
    ```
 
 4. Start integrating Rustic UI Components into your application by importing the necessary components. Below is a sample code snippet demonstrating how to use the MessageSpace component to render messages:

--- a/docs/theme.stories.mdx
+++ b/docs/theme.stories.mdx
@@ -44,11 +44,22 @@ You can empower users to switch between light and dark modes seamlessly. Here's 
 ```
 import React, { useState } from 'react';
 import { ThemeProvider, createTheme, CssBaseline, IconButton } from '@mui/material';
-import { Brightness4 as DarkModeIcon, Brightness7 as LightModeIcon } from '@mui/icons-material';
 import {
   rusticDarkTheme,
   rusticLightTheme,
 } from '@rustic-ai/ui-components'
+
+ const DarkModeToggle = ({ isDarkMode, toggleDarkMode }) => {
+    return (
+      <IconButton onClick={toggleDarkMode}>
+        {isDarkMode ? (
+          <span className="material-symbols-rounded">light_mode</span>
+        ) : (
+          <span className="material-symbols-rounded">dark_mode</span>
+        )}
+      </IconButton>
+    );
+  };
 
 const App = () => {
   const [isDarkMode, setIsDarkMode] = useState(false);
@@ -62,10 +73,7 @@ const App = () => {
     <ThemeProvider theme={isDarkMode ? rusticDarkTheme : rusticLightTheme}>
       <CssBaseline />
       <div>
-        {/* Dark mode toggle button */}
-        <IconButton onClick={toggleDarkMode}>
-          {isDarkMode ? <LightModeIcon /> : <DarkModeIcon />}
-        </IconButton>
+        <DarkModeToggle isDarkMode={isDarkMode} toggleDarkMode={toggleDarkMode} />
         {/* Your application content */}
       </div>
     </ThemeProvider>

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,6 @@
         "@fullcalendar/core": "6.1.10",
         "@fullcalendar/daygrid": "6.1.10",
         "@fullcalendar/react": "6.1.10",
-        "@mui/icons-material": "5.15.8",
         "@mui/material": "5.15.7",
         "@mui/styled-engine-sc": "5.14.11",
         "@mui/system": "5.15.8",
@@ -4235,31 +4234,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/mui-org"
-      }
-    },
-    "node_modules/@mui/icons-material": {
-      "version": "5.15.8",
-      "resolved": "https://registry.npmjs.org/@mui/icons-material/-/icons-material-5.15.8.tgz",
-      "integrity": "sha512-3Ikivf+BOJ7jT1/71HrbKeicgF9ENM4qo+J1050HMJLtLiJEVXbicnsg2oWJZL+0AsrOMaKnTmx1URBpkctLWg==",
-      "dependencies": {
-        "@babel/runtime": "^7.23.9"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/mui-org"
-      },
-      "peerDependencies": {
-        "@mui/material": "^5.0.0",
-        "@types/react": "^17.0.0 || ^18.0.0",
-        "react": "^17.0.0 || ^18.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
       }
     },
     "node_modules/@mui/material": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "@fullcalendar/core": "6.1.10",
     "@fullcalendar/daygrid": "6.1.10",
     "@fullcalendar/react": "6.1.10",
-    "@mui/icons-material": "5.15.8",
     "@mui/material": "5.15.7",
     "@mui/styled-engine-sc": "5.14.11",
     "@mui/system": "5.15.8",

--- a/src/components/chart/rechartsTimeSeries.tsx
+++ b/src/components/chart/rechartsTimeSeries.tsx
@@ -1,7 +1,5 @@
 import './rechartsTimeSeries.css'
 
-import Crop32Icon from '@mui/icons-material/Crop169'
-import MoreVertIcon from '@mui/icons-material/MoreVert'
 import FormControl from '@mui/material/FormControl'
 import IconButton from '@mui/material/IconButton'
 import Menu from '@mui/material/Menu'
@@ -252,17 +250,15 @@ function RechartsTimeSeries(props: RechartsTimeSeriesProps) {
             className="rustic-recharts-time-series-legend-item"
             onClick={() => handleLegendClick(dataKey)}
             data-cy="legend-item"
+            sx={{
+              color: getLegendColor(dataKey, index),
+            }}
           >
-            <Crop32Icon
-              sx={{
-                color: getLegendColor(dataKey, index),
-              }}
-            />
+            <span className="material-symbols-rounded">crop_16_9</span>
             <Typography
               variant="body2"
               display="inline"
               sx={{
-                color: getLegendColor(dataKey, index),
                 textDecorationLine: getLegendTextDecorationStyle(dataKey),
               }}
             >
@@ -297,8 +293,9 @@ function RechartsTimeSeries(props: RechartsTimeSeriesProps) {
               aria-expanded={Boolean(anchorEl)}
               aria-haspopup="true"
               onClick={handleChartTypeToggle}
+              color="primary"
             >
-              <MoreVertIcon sx={{ color: 'primary.main' }} />
+              <span className="material-symbols-rounded">more_vert</span>
             </IconButton>
             <Menu
               anchorOrigin={{

--- a/src/components/chart/rechartsTimeSeries.tsx
+++ b/src/components/chart/rechartsTimeSeries.tsx
@@ -25,6 +25,7 @@ import {
 } from 'recharts'
 
 import { calculateTimeDiffInDays, formatTimestampLabel } from '../helper'
+import Icon from '../icon'
 
 export interface TimeSeriesData {
   timestamp: number
@@ -254,7 +255,7 @@ function RechartsTimeSeries(props: RechartsTimeSeriesProps) {
               color: getLegendColor(dataKey, index),
             }}
           >
-            <span className="material-symbols-rounded">crop_16_9</span>
+            <Icon name="crop_16_9" />
             <Typography
               variant="body2"
               display="inline"
@@ -295,7 +296,7 @@ function RechartsTimeSeries(props: RechartsTimeSeriesProps) {
               onClick={handleChartTypeToggle}
               color="primary"
             >
-              <span className="material-symbols-rounded">more_vert</span>
+              <Icon name="more_vert" />
             </IconButton>
             <Menu
               anchorOrigin={{

--- a/src/components/icon.tsx
+++ b/src/components/icon.tsx
@@ -1,0 +1,18 @@
+import React from 'react'
+
+type IconProps = {
+  name: string
+  className?: string
+}
+export default function Icon(props: IconProps) {
+  const dataCyPrefix = props.name.replaceAll('_', '-')
+
+  return (
+    <span
+      className={`${props.className ? props.className + ' ' : ''}material-symbols-rounded`}
+      data-cy={`${dataCyPrefix}-icon`}
+    >
+      {props.name}
+    </span>
+  )
+}

--- a/src/components/map/openLayersMap.css
+++ b/src/components/map/openLayersMap.css
@@ -3,6 +3,6 @@
   width: 100%;
 }
 
-.rustic-open-layers-map-marker {
+span.rustic-open-layers-map-marker {
   font-size: 40px;
 }

--- a/src/components/map/openLayersMap.cy.tsx
+++ b/src/components/map/openLayersMap.cy.tsx
@@ -19,7 +19,7 @@ describe('Map', () => {
 
     it(`shows the marker on ${viewport} screen`, () => {
       cy.viewport(viewport)
-      cy.get('[data-cy=marker-container] svg')
+      cy.get('[data-cy=marker-container] span')
         .should('be.visible')
         .should('have.class', 'rustic-open-layers-map-marker')
     })

--- a/src/components/map/openLayersMap.tsx
+++ b/src/components/map/openLayersMap.tsx
@@ -12,6 +12,7 @@ import View from 'ol/View.js'
 import React from 'react'
 import { useEffect, useRef, useState } from 'react'
 
+import Icon from '../icon'
 import type { LocationFormat } from '../types'
 
 export default function OpenLayersMap(props: LocationFormat) {
@@ -76,9 +77,10 @@ export default function OpenLayersMap(props: LocationFormat) {
       ) : (
         <Box>
           <Box data-cy="marker-container" ref={markerElement}>
-            <span className="rustic-open-layers-map-marker material-symbols-rounded ">
-              location_on
-            </span>
+            <Icon
+              className="rustic-open-layers-map-marker"
+              name="location_on"
+            />
           </Box>
           <div
             ref={mapTargetElement}

--- a/src/components/map/openLayersMap.tsx
+++ b/src/components/map/openLayersMap.tsx
@@ -1,7 +1,6 @@
 import 'ol/ol.css'
 import './openLayersMap.css'
 
-import PlaceIcon from '@mui/icons-material/Place'
 import Alert from '@mui/material/Alert'
 import Box from '@mui/material/Box'
 import TileLayer from 'ol/layer/Tile.js'
@@ -77,7 +76,9 @@ export default function OpenLayersMap(props: LocationFormat) {
       ) : (
         <Box>
           <Box data-cy="marker-container" ref={markerElement}>
-            <PlaceIcon className="rustic-open-layers-map-marker" />
+            <span className="rustic-open-layers-map-marker material-symbols-rounded ">
+              location_on
+            </span>
           </Box>
           <div
             ref={mapTargetElement}

--- a/src/components/media/controls/commonControls.tsx
+++ b/src/components/media/controls/commonControls.tsx
@@ -9,6 +9,7 @@ import Typography from '@mui/material/Typography'
 import React, { useState } from 'react'
 
 import { formatDurationTime } from '../../helper'
+import Icon from '../../icon'
 import { MediaIconButton } from './mediaIconButton'
 
 export interface MediaControls {
@@ -145,8 +146,6 @@ export function ToggleTranscriptButton(props: ToggleTranscriptButtonProps) {
     ? 'keyboard_arrow_up'
     : 'keyboard_arrow_down'
 
-  const Icon = <span className="material-symbols-rounded">{iconName}</span>
-
   const buttonText = `${props.isTranscriptVisible ? 'Hide' : 'Show'} Transcript`
 
   return (
@@ -154,7 +153,7 @@ export function ToggleTranscriptButton(props: ToggleTranscriptButtonProps) {
       className="rustic-transcript-toggle"
       data-cy="transcript-toggle"
       onClick={props.setIsTranscriptVisible}
-      endIcon={Icon}
+      endIcon={<Icon name={iconName} />}
     >
       <Typography variant="overline">{buttonText}</Typography>
     </Button>

--- a/src/components/media/controls/commonControls.tsx
+++ b/src/components/media/controls/commonControls.tsx
@@ -1,7 +1,5 @@
 import './commonControls.css'
 
-import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown'
-import KeyboardArrowUpIcon from '@mui/icons-material/KeyboardArrowUp'
 import Box from '@mui/material/Box'
 import Button from '@mui/material/Button'
 import LinearProgress from '@mui/material/LinearProgress'
@@ -143,9 +141,11 @@ export function VolumeSettings(props: MediaControls) {
 }
 
 export function ToggleTranscriptButton(props: ToggleTranscriptButtonProps) {
-  const Icon = props.isTranscriptVisible
-    ? KeyboardArrowUpIcon
-    : KeyboardArrowDownIcon
+  const iconName = props.isTranscriptVisible
+    ? 'keyboard_arrow_up'
+    : 'keyboard_arrow_down'
+
+  const Icon = <span className="material-symbols-rounded">{iconName}</span>
 
   const buttonText = `${props.isTranscriptVisible ? 'Hide' : 'Show'} Transcript`
 
@@ -154,7 +154,7 @@ export function ToggleTranscriptButton(props: ToggleTranscriptButtonProps) {
       className="rustic-transcript-toggle"
       data-cy="transcript-toggle"
       onClick={props.setIsTranscriptVisible}
-      endIcon={<Icon />}
+      endIcon={Icon}
     >
       <Typography variant="overline">{buttonText}</Typography>
     </Button>

--- a/src/components/media/controls/mediaIconButton.tsx
+++ b/src/components/media/controls/mediaIconButton.tsx
@@ -1,7 +1,8 @@
-import Icon from '@mui/material/Icon'
 import IconButton from '@mui/material/IconButton'
 import Tooltip from '@mui/material/Tooltip'
 import React from 'react'
+
+import Icon from '../../icon'
 
 interface MediaIconButtonProps {
   onClick: () => void
@@ -54,12 +55,9 @@ export function MediaIconButton(props: MediaIconButtonProps) {
         onClick={props.onClick}
         className={props.className}
         data-cy={`${dataCyPrefix}-button`}
+        color="primary"
       >
-        <Icon color="primary">
-          <span className="material-symbols-rounded">
-            {controls[props.action].symbol}
-          </span>
-        </Icon>
+        <Icon name={controls[props.action].symbol} />
       </IconButton>
     </Tooltip>
   )

--- a/src/components/menu/popoverMenu.cy.tsx
+++ b/src/components/menu/popoverMenu.cy.tsx
@@ -2,6 +2,7 @@
 import React from 'react'
 
 import { supportedViewports } from '../../../cypress/support/variables'
+import Icon from '../icon'
 import PopoverMenu from './popoverMenu'
 
 describe('PopOverMenu', () => {
@@ -13,22 +14,9 @@ describe('PopOverMenu', () => {
   const drawer = '.MuiDrawer-root'
   const popover = '.MuiPopover-root'
 
-  function renderIcon(iconName: string) {
-    const dataCyPrefix = iconName.replaceAll('_', '-')
-
-    return (
-      <span
-        className="material-symbols-rounded"
-        data-cy={`${dataCyPrefix}-icon`}
-      >
-        {iconName}
-      </span>
-    )
-  }
-
-  const checkIcon = renderIcon('check')
-  const thermostatIcon = renderIcon('device_thermostat')
-  const cancelIcon = renderIcon('cancel')
+  const checkIcon = <Icon name="check" />
+  const thermostatIcon = <Icon name="device_thermostat" />
+  const cancelIcon = <Icon name="cancel" />
 
   const menuItems = [
     {

--- a/src/components/menu/popoverMenu.cy.tsx
+++ b/src/components/menu/popoverMenu.cy.tsx
@@ -1,7 +1,4 @@
 /* eslint-disable no-console */
-import CheckIcon from '@mui/icons-material/Check'
-import ClearIcon from '@mui/icons-material/Clear'
-import DeviceThermostatIcon from '@mui/icons-material/DeviceThermostat'
 import React from 'react'
 
 import { supportedViewports } from '../../../cypress/support/variables'
@@ -16,22 +13,39 @@ describe('PopOverMenu', () => {
   const drawer = '.MuiDrawer-root'
   const popover = '.MuiPopover-root'
 
+  function renderIcon(iconName: string) {
+    const dataCyPrefix = iconName.replaceAll('_', '-')
+
+    return (
+      <span
+        className="material-symbols-rounded"
+        data-cy={`${dataCyPrefix}-icon`}
+      >
+        {iconName}
+      </span>
+    )
+  }
+
+  const checkIcon = renderIcon('check')
+  const thermostatIcon = renderIcon('device_thermostat')
+  const cancelIcon = renderIcon('cancel')
+
   const menuItems = [
     {
       label: 'Celsius',
       onClick: () => {
         console.log(celsiusClicked)
       },
-      startDecorator: <DeviceThermostatIcon />,
-      endDecorator: <CheckIcon />,
+      startDecorator: thermostatIcon,
+      endDecorator: checkIcon,
     },
     {
       label: 'Fahrenheit',
       onClick: () => {
         console.log(fahrenheitClicked)
       },
-      startDecorator: <DeviceThermostatIcon />,
-      endDecorator: <ClearIcon />,
+      startDecorator: thermostatIcon,
+      endDecorator: cancelIcon,
     },
   ]
 
@@ -45,9 +59,11 @@ describe('PopOverMenu', () => {
       cy.get(openMenu).click()
       cy.get(popoverMenu).should('be.visible')
       cy.get(`${popoverMenu} li`).should('have.length', menuItems.length)
-      // 4 icons in total should be seen
+
       // eslint-disable-next-line no-magic-numbers
-      cy.get(`${popoverMenu} li svg`).should('have.length', 4)
+      cy.get('[data-cy=device-thermostat-icon]').should('have.length', 2)
+      cy.get('[data-cy=cancel-icon]').should('exist')
+      cy.get('[data-cy=check-icon]').should('exist')
     })
 
     it(`renders the menu items in the order provided on ${viewport} screen`, () => {
@@ -87,8 +103,8 @@ describe('PopOverMenu', () => {
               onClick: (event?: React.MouseEvent<HTMLElement>) => {
                 return console.log(event?.type)
               },
-              startDecorator: <DeviceThermostatIcon />,
-              endDecorator: <ClearIcon />,
+              startDecorator: thermostatIcon,
+              endDecorator: cancelIcon,
             },
           ]}
           ariaLabel={ariaLabel}
@@ -114,7 +130,7 @@ describe('PopOverMenu', () => {
         <PopoverMenu
           menuItems={menuItems}
           ariaLabel={ariaLabel}
-          icon={<DeviceThermostatIcon />}
+          icon={thermostatIcon}
         />
       )
 
@@ -135,7 +151,7 @@ describe('PopOverMenu', () => {
         <PopoverMenu
           menuItems={menuItems}
           ariaLabel={ariaLabel}
-          icon={<DeviceThermostatIcon />}
+          icon={thermostatIcon}
           buttonText="Temperature"
         />
       )

--- a/src/components/menu/popoverMenu.stories.tsx
+++ b/src/components/menu/popoverMenu.stories.tsx
@@ -1,13 +1,5 @@
-import AddBoxIcon from '@mui/icons-material/AddBox'
-import DeleteIcon from '@mui/icons-material/Delete'
-import DeviceThermostatIcon from '@mui/icons-material/DeviceThermostat'
-import EditIcon from '@mui/icons-material/Edit'
-import ExitToAppIcon from '@mui/icons-material/ExitToApp'
-import GroupsIcon from '@mui/icons-material/Groups'
-import IosShareIcon from '@mui/icons-material/IosShare'
-import ListIcon from '@mui/icons-material/List'
-import PushPinIcon from '@mui/icons-material/PushPin'
 import Typography from '@mui/material/Typography'
+import Box from '@mui/system/Box'
 import React from 'react'
 
 import PopoverMenu from './popoverMenu'
@@ -33,54 +25,71 @@ export default {
   },
 }
 
+const pinIcon = <span className="material-symbols-rounded">keep</span>
+const addBoxIcon = (
+  <Box sx={{ color: 'secondary.main' }}>
+    <span className="material-symbols-rounded">add_box</span>
+  </Box>
+)
+const deleteIcon = <span className="material-symbols-rounded">delete</span>
+const thermostatIcon = (
+  <span className="material-symbols-rounded">device_thermostat</span>
+)
+const listIcon = <span className="material-symbols-rounded">list</span>
+
 const defaultMenuItems = [
   {
     label: 'Rename',
     onClick: () => {},
-    startDecorator: <EditIcon />,
+    startDecorator: <span className="material-symbols-rounded">edit</span>,
   },
   {
     label: 'Pin Topic',
     onClick: () => {},
-    startDecorator: <PushPinIcon />,
+    startDecorator: pinIcon,
   },
   {
     label: 'Share',
     onClick: () => {},
-    startDecorator: <IosShareIcon />,
+    startDecorator: <span className="material-symbols-rounded">ios_share</span>,
   },
   {
     label: 'View Participants',
     onClick: () => {},
-    startDecorator: <GroupsIcon />,
+    startDecorator: <span className="material-symbols-rounded">groups</span>,
   },
   {
     label: 'Leave Topic',
     onClick: () => {},
-    startDecorator: <ExitToAppIcon />,
+    startDecorator: (
+      <span className="material-symbols-rounded">exit_to_app</span>
+    ),
   },
   {
     label: 'Delete',
     onClick: () => {},
-    startDecorator: <DeleteIcon />,
+    startDecorator: deleteIcon,
   },
 ]
 
+const renderPinIconWithColor = (
+  <Box sx={{ color: 'secondary.main' }}>{pinIcon}</Box>
+)
 const endDecoratorMenuItems = [
   {
     label: 'Charts',
     onClick: () => {},
-    endDecorator: <PushPinIcon sx={{ color: 'secondary.main' }} />,
+    endDecorator: renderPinIconWithColor,
   },
   {
     label: 'Graphs',
     onClick: () => {},
-    endDecorator: <PushPinIcon sx={{ color: 'secondary.main' }} />,
+    endDecorator: renderPinIconWithColor,
   },
   {
     label: 'Marketing',
     onClick: () => {},
-    endDecorator: <PushPinIcon sx={{ color: 'secondary.main' }} />,
+    endDecorator: renderPinIconWithColor,
   },
 ]
 
@@ -88,14 +97,14 @@ const startAndEndDecoratorMenuItems = [
   {
     label: 'Celsius',
     onClick: () => {},
-    startDecorator: <DeviceThermostatIcon />,
-    endDecorator: <AddBoxIcon sx={{ color: 'secondary.main' }} />,
+    startDecorator: thermostatIcon,
+    endDecorator: addBoxIcon,
   },
   {
     label: 'Fahrenheit',
     onClick: () => {},
-    startDecorator: <DeviceThermostatIcon />,
-    endDecorator: <AddBoxIcon sx={{ color: 'secondary.main' }} />,
+    startDecorator: thermostatIcon,
+    endDecorator: addBoxIcon,
   },
 ]
 
@@ -103,13 +112,13 @@ const textDecorator = [
   {
     label: 'Celsius',
     onClick: () => {},
-    startDecorator: <DeviceThermostatIcon />,
+    startDecorator: thermostatIcon,
     endDecorator: <Typography variant="caption">°C</Typography>,
   },
   {
     label: 'Fahrenheit',
     onClick: () => {},
-    startDecorator: <DeviceThermostatIcon />,
+    startDecorator: thermostatIcon,
     endDecorator: <Typography variant="caption">°F</Typography>,
   },
 ]
@@ -164,7 +173,7 @@ export const WithCustomButtonIcon = {
   args: {
     menuItems: defaultMenuItems,
     ariaLabel: 'open menu showing custom button icon',
-    icon: <ListIcon />,
+    icon: listIcon,
   },
 }
 
@@ -180,7 +189,7 @@ export const WithCustomButtonIconAndText = {
   args: {
     menuItems: defaultMenuItems,
     ariaLabel: 'open menu showing custom button icon and text',
-    icon: <ListIcon />,
+    icon: listIcon,
     buttonText: 'Menu',
   },
 }

--- a/src/components/menu/popoverMenu.stories.tsx
+++ b/src/components/menu/popoverMenu.stories.tsx
@@ -2,6 +2,7 @@ import Typography from '@mui/material/Typography'
 import Box from '@mui/system/Box'
 import React from 'react'
 
+import Icon from '../icon'
 import PopoverMenu from './popoverMenu'
 
 export default {
@@ -25,23 +26,21 @@ export default {
   },
 }
 
-const pinIcon = <span className="material-symbols-rounded">keep</span>
+const pinIcon = <Icon name="keep" />
 const addBoxIcon = (
   <Box sx={{ color: 'secondary.main' }}>
-    <span className="material-symbols-rounded">add_box</span>
+    <Icon name="add_box" />
   </Box>
 )
-const deleteIcon = <span className="material-symbols-rounded">delete</span>
-const thermostatIcon = (
-  <span className="material-symbols-rounded">device_thermostat</span>
-)
-const listIcon = <span className="material-symbols-rounded">list</span>
+const deleteIcon = <Icon name="delete" />
+const thermostatIcon = <Icon name="device_thermostat" />
+const listIcon = <Icon name="list" />
 
 const defaultMenuItems = [
   {
     label: 'Rename',
     onClick: () => {},
-    startDecorator: <span className="material-symbols-rounded">edit</span>,
+    startDecorator: <Icon name="edit" />,
   },
   {
     label: 'Pin Topic',
@@ -51,19 +50,17 @@ const defaultMenuItems = [
   {
     label: 'Share',
     onClick: () => {},
-    startDecorator: <span className="material-symbols-rounded">ios_share</span>,
+    startDecorator: <Icon name="ios_share" />,
   },
   {
     label: 'View Participants',
     onClick: () => {},
-    startDecorator: <span className="material-symbols-rounded">groups</span>,
+    startDecorator: <Icon name="groups" />,
   },
   {
     label: 'Leave Topic',
     onClick: () => {},
-    startDecorator: (
-      <span className="material-symbols-rounded">exit_to_app</span>
-    ),
+    startDecorator: <Icon name="exit_to_app" />,
   },
   {
     label: 'Delete',

--- a/src/components/menu/popoverMenu.tsx
+++ b/src/components/menu/popoverMenu.tsx
@@ -13,6 +13,8 @@ import { Box } from '@mui/system'
 import type { ReactNode } from 'react'
 import React, { useRef, useState } from 'react'
 
+import Icon from '../icon'
+
 export interface PopoverMenuItem {
   label: string
   onClick: (event?: React.MouseEvent<HTMLElement>) => void
@@ -97,9 +99,7 @@ export default function PopoverMenu(props: PopoverMenuProps) {
       className: 'rustic-popover-menu-button',
     }
 
-    const defaultIcon = (
-      <span className="material-symbols-rounded">more_vert</span>
-    )
+    const defaultIcon = <Icon name="more_vert" />
 
     if (props.buttonText) {
       return (

--- a/src/components/menu/popoverMenu.tsx
+++ b/src/components/menu/popoverMenu.tsx
@@ -1,6 +1,5 @@
 import './popoverMenu.css'
 
-import MoreVertIcon from '@mui/icons-material/MoreVert'
 import { useMediaQuery } from '@mui/material'
 import Button from '@mui/material/Button'
 import Drawer from '@mui/material/Drawer'
@@ -98,6 +97,10 @@ export default function PopoverMenu(props: PopoverMenuProps) {
       className: 'rustic-popover-menu-button',
     }
 
+    const defaultIcon = (
+      <span className="material-symbols-rounded">more_vert</span>
+    )
+
     if (props.buttonText) {
       return (
         <Button
@@ -111,7 +114,7 @@ export default function PopoverMenu(props: PopoverMenuProps) {
     } else {
       return (
         <IconButton {...buttonAttributes} data-cy="menu-icon-button">
-          {props.icon ? props.icon : <MoreVertIcon />}
+          {props.icon ? props.icon : defaultIcon}
         </IconButton>
       )
     }

--- a/src/components/messageCanvas/messageCanvas.cy.tsx
+++ b/src/components/messageCanvas/messageCanvas.cy.tsx
@@ -2,6 +2,7 @@
 import 'cypress-real-events'
 
 import { supportedViewports } from '../../../cypress/support/variables'
+import Icon from '../icon'
 import MessageCanvas from './messageCanvas'
 
 describe('MessageCanvas', () => {
@@ -35,16 +36,7 @@ describe('MessageCanvas', () => {
       cy.mount(
         <MessageCanvas
           message={testMessage}
-          getProfileComponent={() => {
-            return (
-              <span
-                className="material-symbols-rounded"
-                data-cy="account-circle-icon"
-              >
-                account_circle
-              </span>
-            )
-          }}
+          getProfileComponent={() => <Icon name="account_circle" />}
         >
           <p>Hello World</p>
         </MessageCanvas>

--- a/src/components/messageCanvas/messageCanvas.cy.tsx
+++ b/src/components/messageCanvas/messageCanvas.cy.tsx
@@ -1,8 +1,6 @@
 /* eslint-disable no-magic-numbers */
 import 'cypress-real-events'
 
-import AccountCircleIcon from '@mui/icons-material/AccountCircle'
-
 import { supportedViewports } from '../../../cypress/support/variables'
 import MessageCanvas from './messageCanvas'
 
@@ -38,7 +36,14 @@ describe('MessageCanvas', () => {
         <MessageCanvas
           message={testMessage}
           getProfileComponent={() => {
-            return <AccountCircleIcon />
+            return (
+              <span
+                className="material-symbols-rounded"
+                data-cy="account-circle-icon"
+              >
+                account_circle
+              </span>
+            )
           }}
         >
           <p>Hello World</p>
@@ -47,7 +52,7 @@ describe('MessageCanvas', () => {
 
       cy.contains('Hello World').should('be.visible')
       cy.contains('senderId').should('be.visible')
-      cy.get('[data-testid="AccountCircleIcon"]').should('be.visible')
+      cy.get('[data-cy="account-circle-icon"]').should('be.visible')
     })
   })
 

--- a/src/components/messageCanvas/messageCanvas.stories.tsx
+++ b/src/components/messageCanvas/messageCanvas.stories.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 
 import { ElementRenderer, type ThreadableMessage } from '..'
+import Icon from '../icon'
 import Text from '../text/text'
 import MessageCanvas from './messageCanvas'
 
@@ -52,16 +53,9 @@ export const WithProfileIcon = {
     message: messageFromHuman,
     getProfileComponent: (message: ThreadableMessage) => {
       if (message.sender.includes('agent')) {
-        return <span className="material-symbols-rounded">smart_toy</span>
+        return <Icon name="smart_toy" />
       } else {
-        return (
-          <span
-            className="material-symbols-rounded"
-            data-cy="account-circle-icon"
-          >
-            account_circle
-          </span>
-        )
+        return <Icon name="account_circle" />
       }
     },
   },

--- a/src/components/messageCanvas/messageCanvas.stories.tsx
+++ b/src/components/messageCanvas/messageCanvas.stories.tsx
@@ -1,5 +1,3 @@
-import AccountCircleIcon from '@mui/icons-material/AccountCircle'
-import SmartToyIcon from '@mui/icons-material/SmartToy'
 import React from 'react'
 
 import { ElementRenderer, type ThreadableMessage } from '..'
@@ -54,9 +52,16 @@ export const WithProfileIcon = {
     message: messageFromHuman,
     getProfileComponent: (message: ThreadableMessage) => {
       if (message.sender.includes('agent')) {
-        return <SmartToyIcon />
+        return <span className="material-symbols-rounded">smart_toy</span>
       } else {
-        return <AccountCircleIcon />
+        return (
+          <span
+            className="material-symbols-rounded"
+            data-cy="account-circle-icon"
+          >
+            account_circle
+          </span>
+        )
       }
     },
   },

--- a/src/components/messageSpace/messageSpace.cy.tsx
+++ b/src/components/messageSpace/messageSpace.cy.tsx
@@ -14,6 +14,7 @@ import {
   Text,
   YoutubeVideo,
 } from '..'
+import Icon from '../icon'
 import MessageSpace from './messageSpace'
 
 describe('MessageSpace Component', () => {
@@ -80,17 +81,9 @@ describe('MessageSpace Component', () => {
           supportedElements={supportedElements}
           getProfileComponent={(message: Message) => {
             if (message.sender.includes('Agent')) {
-              return (
-                <span className="material-symbols-rounded" data-cy="agent-icon">
-                  smart_toy
-                </span>
-              )
+              return <Icon name="smart_toy" />
             } else {
-              return (
-                <span className="material-symbols-rounded" data-cy="human-icon">
-                  account_circle
-                </span>
-              )
+              return <Icon name="account_circle" />
             }
           }}
         />
@@ -107,13 +100,13 @@ describe('MessageSpace Component', () => {
           cy.get(messageCanvas)
             .eq(index)
             .within(() => {
-              cy.get('span[data-cy="agent-icon"]').should('exist')
+              cy.get('span[data-cy="smart-toy-icon"]').should('exist')
             })
         } else {
           cy.get(messageCanvas)
             .eq(index)
             .within(() => {
-              cy.get('span[data-cy="human-icon"]').should('exist')
+              cy.get('span[data-cy="account-circle-icon"]').should('exist')
             })
         }
       })

--- a/src/components/messageSpace/messageSpace.cy.tsx
+++ b/src/components/messageSpace/messageSpace.cy.tsx
@@ -1,5 +1,3 @@
-import AccountCircleIcon from '@mui/icons-material/AccountCircle'
-import SmartToyIcon from '@mui/icons-material/SmartToy'
 import { v4 as getUUID } from 'uuid'
 
 import { supportedViewports } from '../../../cypress/support/variables'
@@ -82,15 +80,23 @@ describe('MessageSpace Component', () => {
           supportedElements={supportedElements}
           getProfileComponent={(message: Message) => {
             if (message.sender.includes('Agent')) {
-              return <SmartToyIcon data-cy="agent-icon" />
+              return (
+                <span className="material-symbols-rounded" data-cy="agent-icon">
+                  smart_toy
+                </span>
+              )
             } else {
-              return <AccountCircleIcon data-cy="human-icon" />
+              return (
+                <span className="material-symbols-rounded" data-cy="human-icon">
+                  account_circle
+                </span>
+              )
             }
           }}
         />
       )
       const messageSpace = '[data-cy=message-space]'
-
+      const messageCanvas = '[data-cy=message-canvas]'
       cy.get(messageSpace).should('exist')
 
       messages.forEach((message, index) => {
@@ -98,9 +104,17 @@ describe('MessageSpace Component', () => {
           .should('contain', message.sender)
           .and('contain', message.data.text)
         if (message.sender === 'Agent') {
-          cy.get('svg').eq(index).should('have.attr', 'data-cy', 'agent-icon')
+          cy.get(messageCanvas)
+            .eq(index)
+            .within(() => {
+              cy.get('span[data-cy="agent-icon"]').should('exist')
+            })
         } else {
-          cy.get('svg').eq(index).should('have.attr', 'data-cy', 'human-icon')
+          cy.get(messageCanvas)
+            .eq(index)
+            .within(() => {
+              cy.get('span[data-cy="human-icon"]').should('exist')
+            })
         }
       })
     })

--- a/src/components/messageSpace/messageSpace.stories.tsx
+++ b/src/components/messageSpace/messageSpace.stories.tsx
@@ -15,6 +15,7 @@ import {
   YoutubeVideo,
 } from '..'
 import CodeSnippet from '../codeSnippet/codeSnippet'
+import Icon from '../icon'
 import MessageSpace from './messageSpace'
 
 export default {
@@ -139,9 +140,6 @@ const tableData = [
 
 const chartColors = ['#648FFF', '#785EF0', '#DC267F', '#FE6100', '#FFB000']
 
-function renderIcon(iconName: string) {
-  return <span className="material-symbols-rounded">{iconName}</span>
-}
 export const Default = {
   args: {
     messages: [
@@ -350,9 +348,9 @@ export const Default = {
     },
     getProfileComponent: (message: Message) => {
       if (message.sender.includes('Agent')) {
-        return renderIcon('smart_toy')
+        return <Icon name="smart_toy" />
       } else {
-        return renderIcon('account_circle')
+        return <Icon name="account_circle" />
       }
     },
   },

--- a/src/components/messageSpace/messageSpace.stories.tsx
+++ b/src/components/messageSpace/messageSpace.stories.tsx
@@ -1,5 +1,3 @@
-import AccountCircleIcon from '@mui/icons-material/AccountCircle'
-import SmartToyIcon from '@mui/icons-material/SmartToy'
 import React from 'react'
 import { v4 as getUUID } from 'uuid'
 
@@ -141,6 +139,9 @@ const tableData = [
 
 const chartColors = ['#648FFF', '#785EF0', '#DC267F', '#FE6100', '#FFB000']
 
+function renderIcon(iconName: string) {
+  return <span className="material-symbols-rounded">{iconName}</span>
+}
 export const Default = {
   args: {
     messages: [
@@ -349,9 +350,9 @@ export const Default = {
     },
     getProfileComponent: (message: Message) => {
       if (message.sender.includes('Agent')) {
-        return <SmartToyIcon />
+        return renderIcon('smart_toy')
       } else {
-        return <AccountCircleIcon />
+        return renderIcon('account_circle')
       }
     },
   },

--- a/src/components/navBar/navBar.cy.tsx
+++ b/src/components/navBar/navBar.cy.tsx
@@ -1,4 +1,5 @@
 import { supportedViewports } from '../../../cypress/support/variables'
+import Icon from '../icon'
 import NavBar from './navBar'
 
 describe('NavBar', () => {
@@ -15,16 +16,12 @@ describe('NavBar', () => {
   // eslint-disable-next-line no-console
   const openRightDrawer = () => console.log('right drawer opened')
 
-  function renderIcon(iconName: string) {
-    return <span className="material-symbols-rounded">{iconName}</span>
-  }
-
   beforeEach(() => {
     cy.mount(
       <NavBar
         logo={<Logo />}
-        leftDrawerIcon={renderIcon('bookmark')}
-        rightDrawerIcon={renderIcon('chat')}
+        leftDrawerIcon={<Icon name="bookmark" />}
+        rightDrawerIcon={<Icon name="chat" />}
         leftDrawerAriaLabel="open left drawer"
         rightDrawerAriaLabel="open right drawer"
         handleLeftDrawerToggle={openLeftDrawer}

--- a/src/components/navBar/navBar.cy.tsx
+++ b/src/components/navBar/navBar.cy.tsx
@@ -1,6 +1,3 @@
-import BookmarkIcon from '@mui/icons-material/Bookmark'
-import MessageIcon from '@mui/icons-material/Message'
-
 import { supportedViewports } from '../../../cypress/support/variables'
 import NavBar from './navBar'
 
@@ -18,12 +15,16 @@ describe('NavBar', () => {
   // eslint-disable-next-line no-console
   const openRightDrawer = () => console.log('right drawer opened')
 
+  function renderIcon(iconName: string) {
+    return <span className="material-symbols-rounded">{iconName}</span>
+  }
+
   beforeEach(() => {
     cy.mount(
       <NavBar
         logo={<Logo />}
-        leftDrawerIcon={<BookmarkIcon />}
-        rightDrawerIcon={<MessageIcon />}
+        leftDrawerIcon={renderIcon('bookmark')}
+        rightDrawerIcon={renderIcon('chat')}
         leftDrawerAriaLabel="open left drawer"
         rightDrawerAriaLabel="open right drawer"
         handleLeftDrawerToggle={openLeftDrawer}

--- a/src/components/navBar/navBar.stories.tsx
+++ b/src/components/navBar/navBar.stories.tsx
@@ -1,6 +1,4 @@
 /* eslint-disable @typescript-eslint/no-empty-function */
-import BookmarkIcon from '@mui/icons-material/Bookmark'
-import MessageIcon from '@mui/icons-material/Message'
 import Typography from '@mui/material/Typography'
 import { Box } from '@mui/system'
 import React from 'react'
@@ -32,11 +30,15 @@ const Logo = () => {
   )
 }
 
+function renderIcon(iconName: string) {
+  return <span className="material-symbols-rounded">{iconName}</span>
+}
+
 export const Default = {
   args: {
     logo: <Logo />,
-    leftDrawerIcon: <MessageIcon />,
-    rightDrawerIcon: <BookmarkIcon />,
+    leftDrawerIcon: renderIcon('chat'),
+    rightDrawerIcon: renderIcon('bookmark'),
     leftDrawerAriaLabel: 'Open Left Drawer',
     rightDrawerAriaLabel: 'Open Right Drawer',
     handleLeftDrawerToggle: () => {},

--- a/src/components/navBar/navBar.stories.tsx
+++ b/src/components/navBar/navBar.stories.tsx
@@ -3,6 +3,7 @@ import Typography from '@mui/material/Typography'
 import { Box } from '@mui/system'
 import React from 'react'
 
+import Icon from '../icon'
 import NavBar from './navBar'
 
 const meta = {
@@ -30,15 +31,11 @@ const Logo = () => {
   )
 }
 
-function renderIcon(iconName: string) {
-  return <span className="material-symbols-rounded">{iconName}</span>
-}
-
 export const Default = {
   args: {
     logo: <Logo />,
-    leftDrawerIcon: renderIcon('chat'),
-    rightDrawerIcon: renderIcon('bookmark'),
+    leftDrawerIcon: <Icon name="chat" />,
+    rightDrawerIcon: <Icon name="bookmark" />,
     leftDrawerAriaLabel: 'Open Left Drawer',
     rightDrawerAriaLabel: 'Open Right Drawer',
     handleLeftDrawerToggle: () => {},

--- a/src/components/participantsContainer/participantsContainer.cy.tsx
+++ b/src/components/participantsContainer/participantsContainer.cy.tsx
@@ -83,7 +83,7 @@ describe('ParticipantsContainer', () => {
 
       cy.get(toggleParticipantListButton)
         .first()
-        .should('have.text', `Show All ${participantsVisbileAfterShowAll}`)
+        .should('contain', `Show All ${participantsVisbileAfterShowAll}`)
 
       cy.get(toggleParticipantListButton).first().click()
       cy.get(participantList)
@@ -91,9 +91,7 @@ describe('ParticipantsContainer', () => {
         .find(participantListItem)
         .should('have.length', participantsVisbileAfterShowAll)
 
-      cy.get(toggleParticipantListButton)
-        .first()
-        .should('have.text', 'Show Less')
+      cy.get(toggleParticipantListButton).first().should('contain', 'Show Less')
     })
   })
 })

--- a/src/components/participantsContainer/participantsContainer.tsx
+++ b/src/components/participantsContainer/participantsContainer.tsx
@@ -15,6 +15,7 @@ import React from 'react'
 import { useState } from 'react'
 
 import { capitalizeFirstLetter } from '../helper'
+import Icon from '../icon'
 import { type Participant, ParticipantRole, ParticipantType } from '../types'
 
 export interface ParticipantsContainerProps {
@@ -23,10 +24,6 @@ export interface ParticipantsContainerProps {
   isParticipantListOpen: boolean
   /** Callback function to close the participants modal. */
   onClose: () => void
-}
-
-function renderIcon(iconName: string) {
-  return <span className="material-symbols-rounded">{iconName}</span>
 }
 
 const ParticipantList = (props: {
@@ -86,7 +83,7 @@ const ParticipantList = (props: {
                 }
                 color="primary"
                 size="small"
-                startIcon={renderIcon('keyboard_arrow_down')}
+                startIcon={<Icon name="keyboard_arrow_down" />}
               >
                 {buttonLabel}
               </Button>
@@ -178,7 +175,7 @@ const ParticipantsContainer = (props: ParticipantsContainerProps) => {
 
       <ParticipantList
         participantType="Human"
-        participantTypeIcon={renderIcon('account_circle')}
+        participantTypeIcon={<Icon name="account_circle" />}
         participants={sortedHumanParticipants}
       />
 
@@ -188,7 +185,7 @@ const ParticipantsContainer = (props: ParticipantsContainerProps) => {
 
           <ParticipantList
             participantType="Agent"
-            participantTypeIcon={renderIcon('smart_toy')}
+            participantTypeIcon={<Icon name="smart_toy" />}
             participants={sortedAgentParticipants}
           />
         </>

--- a/src/components/participantsContainer/participantsContainer.tsx
+++ b/src/components/participantsContainer/participantsContainer.tsx
@@ -1,8 +1,5 @@
 import './participantsContainer.css'
 
-import AccountCircleIcon from '@mui/icons-material/AccountCircle'
-import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown'
-import SmartToy from '@mui/icons-material/SmartToy'
 import Button from '@mui/material/Button'
 import Dialog from '@mui/material/Dialog'
 import DialogTitle from '@mui/material/DialogTitle'
@@ -26,6 +23,10 @@ export interface ParticipantsContainerProps {
   isParticipantListOpen: boolean
   /** Callback function to close the participants modal. */
   onClose: () => void
+}
+
+function renderIcon(iconName: string) {
+  return <span className="material-symbols-rounded">{iconName}</span>
 }
 
 const ParticipantList = (props: {
@@ -85,7 +86,7 @@ const ParticipantList = (props: {
                 }
                 color="primary"
                 size="small"
-                startIcon={<KeyboardArrowDownIcon />}
+                startIcon={renderIcon('keyboard_arrow_down')}
               >
                 {buttonLabel}
               </Button>
@@ -177,7 +178,7 @@ const ParticipantsContainer = (props: ParticipantsContainerProps) => {
 
       <ParticipantList
         participantType="Human"
-        participantTypeIcon={<AccountCircleIcon />}
+        participantTypeIcon={renderIcon('account_circle')}
         participants={sortedHumanParticipants}
       />
 
@@ -187,7 +188,7 @@ const ParticipantsContainer = (props: ParticipantsContainerProps) => {
 
           <ParticipantList
             participantType="Agent"
-            participantTypeIcon={<SmartToy />}
+            participantTypeIcon={renderIcon('smart_toy')}
             participants={sortedAgentParticipants}
           />
         </>

--- a/src/components/textInput/textInput.tsx
+++ b/src/components/textInput/textInput.tsx
@@ -11,6 +11,7 @@ import { useRef, useState } from 'react'
 import React from 'react'
 import { v4 as getUUID } from 'uuid'
 
+import Icon from '../icon'
 import type { Message, WebSocketClient } from '../types'
 
 export interface TextInputProps {
@@ -82,9 +83,7 @@ export default function TextInput(props: TextInputProps) {
               size="small"
               sx={{ color: speechToTextIconColor }}
             >
-              <span className="material-symbols-rounded">
-                {speechToTextIconName}
-              </span>
+              <Icon name={speechToTextIconName} />
             </IconButton>
           </Tooltip>
         )}
@@ -210,7 +209,7 @@ export default function TextInput(props: TextInputProps) {
         disabled={isEmptyMessage}
         color="primary"
       >
-        <span className="material-symbols-rounded">send</span>
+        <Icon name="send" />
       </IconButton>
     </Box>
   )

--- a/src/components/tooltip/tooltip.stories.tsx
+++ b/src/components/tooltip/tooltip.stories.tsx
@@ -2,6 +2,8 @@ import IconButton from '@mui/material/IconButton'
 import Tooltip from '@mui/material/Tooltip'
 import React from 'react'
 
+import Icon from '../icon'
+
 export default {
   title: 'Rustic UI/Tooltip/Tooltip',
   component: Tooltip,
@@ -19,7 +21,7 @@ export default {
 
 const notificationsIcon = (
   <IconButton>
-    <span className="material-symbols-rounded">notifications</span>
+    <Icon name="notifications" />
   </IconButton>
 )
 

--- a/src/components/tooltip/tooltip.stories.tsx
+++ b/src/components/tooltip/tooltip.stories.tsx
@@ -1,4 +1,3 @@
-import NotificationsIcon from '@mui/icons-material/Notifications'
 import IconButton from '@mui/material/IconButton'
 import Tooltip from '@mui/material/Tooltip'
 import React from 'react'
@@ -18,14 +17,16 @@ export default {
   },
 }
 
+const notificationsIcon = (
+  <IconButton>
+    <span className="material-symbols-rounded">notifications</span>
+  </IconButton>
+)
+
 export const Default = {
   args: {
     title: 'Notifications',
-    children: (
-      <IconButton>
-        <NotificationsIcon />
-      </IconButton>
-    ),
+    children: notificationsIcon,
   },
   parameters: {
     docs: {
@@ -43,11 +44,7 @@ export const Default = {
 export const ShowAtTop = {
   args: {
     title: 'Notifications',
-    children: (
-      <IconButton>
-        <NotificationsIcon />
-      </IconButton>
-    ),
+    children: notificationsIcon,
     placement: 'top',
   },
   parameters: {
@@ -66,11 +63,7 @@ export const ShowAtTop = {
 export const CustomizeDistance = {
   args: {
     title: 'Notifications',
-    children: (
-      <IconButton>
-        <NotificationsIcon />
-      </IconButton>
-    ),
+    children: notificationsIcon,
     placement: 'top',
     slotProps: {
       popper: {


### PR DESCRIPTION
## Changes
- Replace MUI icons with material symbols
- Uninstall `@mui/icons-material`
- Update related tests/stories
- Create an Icon component to render material symbols 

Note: some icons look slightly different from what we used before. Screenshots are attached

## Screenshots
### Before
<img width="750" alt="Screenshot 2024-04-23 at 2 37 55 PM" src="https://github.com/rustic-ai/ui-components/assets/103023797/d0d26db7-733c-4aaf-afca-109e8700bd09">
<img width="717" alt="Screenshot 2024-04-23 at 2 38 36 PM" src="https://github.com/rustic-ai/ui-components/assets/103023797/bcafcdd3-05cb-4902-8ace-81a44b516265">
<img width="298" alt="Screenshot 2024-04-23 at 2 41 14 PM" src="https://github.com/rustic-ai/ui-components/assets/103023797/7a24ab73-62f1-447b-9487-cd21fc548c88">
<img width="929" alt="Screenshot 2024-04-23 at 2 43 04 PM" src="https://github.com/rustic-ai/ui-components/assets/103023797/8f156a73-281a-4efa-b5e7-11876b163e5b">
<img width="731" alt="Screenshot 2024-04-23 at 2 44 05 PM" src="https://github.com/rustic-ai/ui-components/assets/103023797/4a77c16f-2d77-402d-93e4-52791e0f862c">


### After
Could use the outlined version which looks same as before, but we need to add <link> for it. Since other icons are not using the outlined version, I'm wondering if we could use rounded version for this
<img width="743" alt="Screenshot 2024-04-23 at 2 35 32 PM" src="https://github.com/rustic-ai/ui-components/assets/103023797/63e5c854-56e7-4bc7-bb3c-426a962898ca">
Looks more rounded than before
<img width="732" alt="Screenshot 2024-04-23 at 2 38 21 PM" src="https://github.com/rustic-ai/ui-components/assets/103023797/2806c554-620a-4a89-a1ea-c0125ff6c574">
The edit and delete icons look a little bit different
<img width="319" alt="Screenshot 2024-04-23 at 2 40 46 PM" src="https://github.com/rustic-ai/ui-components/assets/103023797/b5ea994d-1afb-479e-b8ab-b9a177594746">
The filled area is flipped
<img width="950" alt="Screenshot 2024-04-23 at 2 42 30 PM" src="https://github.com/rustic-ai/ui-components/assets/103023797/32dc7d94-cd1c-4768-b83b-ed4d41fac855">
The collection icon is more rounded and the chat icon has a shorter line at bottom
<img width="734" alt="Screenshot 2024-04-23 at 2 43 35 PM" src="https://github.com/rustic-ai/ui-components/assets/103023797/599a2719-f4da-4bed-bcf9-1728a282b9bf">