### PR TITLE
chore: update cypress config for expirimental safari support

### DIFF
--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -3,6 +3,7 @@ import { defineConfig } from 'cypress'
 import webpackConfig from './webpack.config'
 
 export default defineConfig({
+  experimentalWebKitSupport: true,
   chromeWebSecurity: false,
   component: {
     devServer: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -71,6 +71,7 @@
         "husky": "8.0.3",
         "lint-staged": "15.2.2",
         "mini-css-extract-plugin": "2.8.1",
+        "playwright-webkit": "1.34.3",
         "prettier": "3.2.5",
         "prop-types": "15.8.1",
         "storybook": "7.6.17",
@@ -17359,6 +17360,34 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.34.3",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.34.3.tgz",
+      "integrity": "sha512-2pWd6G7OHKemc5x1r1rp8aQcpvDh7goMBZlJv6Co5vCNLVcQJdhxRL09SGaY6HcyHH9aT4tiynZabMofVasBYw==",
+      "dev": true,
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/playwright-webkit": {
+      "version": "1.34.3",
+      "resolved": "https://registry.npmjs.org/playwright-webkit/-/playwright-webkit-1.34.3.tgz",
+      "integrity": "sha512-F5JJlmq1VvRpblPgYId2/NZb/WycNgSBgv9siF8H1yFbcssohNLEwHyG3U7QWqr3FAa07XEr5EVj3pnzLnR2eQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "dependencies": {
+        "playwright-core": "1.34.3"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/pluralize": {

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "husky": "8.0.3",
     "lint-staged": "15.2.2",
     "mini-css-extract-plugin": "2.8.1",
+    "playwright-webkit": "1.34.3",
     "prettier": "3.2.5",
     "prop-types": "15.8.1",
     "storybook": "7.6.17",


### PR DESCRIPTION
## Changes
- update cypress config for experimental safari support

Safari is not yet fully supported, but Cypress offers [experimental support](https://docs.cypress.io/guides/guides/launching-browsers#WebKit-Experimental).