### PR TITLE
fix: update navbar padding to match design

### DIFF
--- a/src/components/navBar/navBar.css
+++ b/src/components/navBar/navBar.css
@@ -1,8 +1,7 @@
 .rustic-nav-bar {
   height: 72px;
   justify-content: space-between;
-  padding-left: 24px;
-  padding-right: 24px;
+  padding: 16px;
 }
 
 .rustic-nav-bar-button {


### PR DESCRIPTION
Resolves #94 

## Changes
- Update navbar padding to match design

## Before
<img width="1073" alt="Screenshot 2024-04-26 at 4 53 39 PM" src="https://github.com/rustic-ai/ui-components/assets/103023797/1de8f5bb-2547-459a-9d12-97054a756896">

## After
<img width="1072" alt="Screenshot 2024-04-26 at 4 51 35 PM" src="https://github.com/rustic-ai/ui-components/assets/103023797/c1cc9c2c-4da6-4b3a-a028-4c030ee59734">
