### PR TITLE
fix(messageCanvas): adjust alignment of sender info

### DIFF
--- a/src/components/messageCanvas/messageCanvas.css
+++ b/src/components/messageCanvas/messageCanvas.css
@@ -10,6 +10,7 @@
 
 .rustic-message-canvas .rustic-sender-info {
   display: flex;
+  align-items: center;
   gap: 8px;
 }
 


### PR DESCRIPTION
## Changes
- fix alignment of sender info

This PR addresses issue #110.

## Screenshots
### Before
<img width="465" alt="Screenshot 2024-05-02 at 9 28 39 AM" src="https://github.com/rustic-ai/ui-components/assets/111031789/5e809627-6e4b-4163-afc2-8222e50fdc74">

### After
<img width="465" alt="Screenshot 2024-05-02 at 9 28 30 AM" src="https://github.com/rustic-ai/ui-components/assets/111031789/57cd706b-704f-4f3c-99a7-ad0151047b07">
