### PR TITLE
fix: update timestamp format

### DIFF
--- a/cypress/unit/formatDateAndTime.cy.ts
+++ b/cypress/unit/formatDateAndTime.cy.ts
@@ -8,12 +8,12 @@ describe('formatDateAndTime', () => {
   it('should format the date correctly', () => {
     const utcTimestamp = '2023-01-01T12:00:00Z'
     const formatted = formatDateAndTime(utcTimestamp)
-    expect(formatted).to.eq('Jan 1 4:00 AM')
+    expect(formatted).to.eq('Jan 1, 4:00 AM')
   })
 
-  it('should include year when the time difference is more than 365 days', () => {
+  it('should include the year when showing a date from a different year', () => {
     const utcTimestamp = '2022-01-01T12:00:00Z'
     const formatted = formatDateAndTime(utcTimestamp)
-    expect(formatted).to.eq('Jan 1 2022 4:00 AM')
+    expect(formatted).to.eq('Jan 1, 2022 at 4:00 AM')
   })
 })

--- a/cypress/unit/formatMessageTimestamp.cy.ts
+++ b/cypress/unit/formatMessageTimestamp.cy.ts
@@ -12,7 +12,7 @@ describe('formatTimestamp', () => {
 
   it('should return date and time when time difference is more than 24 hours', () => {
     const utcTimestamp = '2021-01-01T00:00:00Z'
-    const expected = 'Dec 31 2020 4:00 PM'
+    const expected = 'Dec 31, 2020 at 4:00 PM'
     const result = formatMessageTimestamp(utcTimestamp)
     expect(result).to.eq(expected)
   })

--- a/src/components/helper.ts
+++ b/src/components/helper.ts
@@ -39,7 +39,7 @@ export function formatDateAndTime(isoDateTimeInUtc: string): string {
   const isDifferentYear =
     convertedDate.getFullYear() !== currentDate.getFullYear()
 
-  const dataAndTimeConnector = isDifferentYear ? ' at ' : ', '
+  const dateAndTimeConnector = isDifferentYear ? ' at ' : ', '
 
   if (isDifferentYear) {
     dateOptions.year = 'numeric'
@@ -47,7 +47,7 @@ export function formatDateAndTime(isoDateTimeInUtc: string): string {
 
   const formattedDateTime =
     convertedDate.toLocaleDateString(userLocale, dateOptions) +
-    dataAndTimeConnector +
+    dateAndTimeConnector +
     convertedDate.toLocaleTimeString(userLocale, timeOptions)
   return formattedDateTime
 }

--- a/src/components/helper.ts
+++ b/src/components/helper.ts
@@ -24,23 +24,31 @@ export function calculateTimeAgo(isoDate: string): string {
 export function formatDateAndTime(isoDateTimeInUtc: string): string {
   const convertedDate = new Date(isoDateTimeInUtc)
   const userLocale = navigator.language
-  const options: Intl.DateTimeFormatOptions = {
+  const dateOptions: Intl.DateTimeFormatOptions = {
     month: 'short',
     day: 'numeric',
+  }
+
+  const timeOptions: Intl.DateTimeFormatOptions = {
     hour: 'numeric',
     minute: '2-digit',
     hour12: true,
   }
 
-  const timeDifferenceInDays =
-    calculateTimeDiffInSeconds(isoDateTimeInUtc) / (60 * 60 * 24)
+  const currentDate = new Date()
+  const isDifferentYear =
+    convertedDate.getFullYear() !== currentDate.getFullYear()
 
-  if (timeDifferenceInDays > 365) {
-    options.year = 'numeric'
+  const dataAndTimeConnector = isDifferentYear ? ' at ' : ', '
+
+  if (isDifferentYear) {
+    dateOptions.year = 'numeric'
   }
-  const formattedDateTime = convertedDate
-    .toLocaleTimeString(userLocale, options)
-    .replace(/,/g, '')
+
+  const formattedDateTime =
+    convertedDate.toLocaleDateString(userLocale, dateOptions) +
+    dataAndTimeConnector +
+    convertedDate.toLocaleTimeString(userLocale, timeOptions)
   return formattedDateTime
 }
 

--- a/src/components/messageCanvas/messageCanvas.cy.tsx
+++ b/src/components/messageCanvas/messageCanvas.cy.tsx
@@ -59,9 +59,9 @@ describe('MessageCanvas', () => {
           <p>Hello World</p>
         </MessageCanvas>
       )
-      cy.contains('Jan 1 2020').should('not.be.visible')
+      cy.contains('Jan 1, 2020').should('not.be.visible')
       cy.get('.rustic-message-canvas').realHover()
-      cy.contains('Jan 1 2020').should('be.visible')
+      cy.contains('Jan 1, 2020').should('be.visible')
     })
 
     it('shows that it was last updated if an update is provided', () => {
@@ -87,9 +87,9 @@ describe('MessageCanvas', () => {
           <p>Hello World</p>
         </MessageCanvas>
       )
-      cy.contains('Jan 1 2020').should('not.be.visible')
+      cy.contains('Jan 1, 2020').should('not.be.visible')
       cy.get('.rustic-message-canvas').realTouch()
-      cy.contains('Jan 1 2020').should('be.visible')
+      cy.contains('Jan 1, 2020').should('be.visible')
     })
 
     it('shows that it was last updated if an update is provided', () => {

--- a/src/components/timestamp/timestamp.stories.tsx
+++ b/src/components/timestamp/timestamp.stories.tsx
@@ -15,15 +15,36 @@ export default {
   },
 }
 
-const newDate = new Date()
+function getYesterdayDate() {
+  const today = new Date()
+  const yesterday = new Date(today)
+  yesterday.setDate(today.getDate() - 1)
+  return yesterday
+}
+
+const yesterday = getYesterdayDate()
+const now = new Date()
+
 export const Default = {
   args: {
     timestamp: '2023-11-26T23:25:44Z',
   },
 }
 
+export const OverADayAgo = {
+  args: {
+    timestamp: yesterday,
+  },
+}
+
+export const NotThisYear = {
+  args: {
+    timestamp: '2022-11-26T23:25:44Z',
+  },
+}
+
 export const TimeAgo = {
   args: {
-    timestamp: newDate,
+    timestamp: now,
   },
 }


### PR DESCRIPTION
## Changes
- update timestamp format of `formatDateAndTime` output based on issue #111
- add more stories to `TimeStamp`

## Screenshots
### MessageCanvas
#### Before
<img width="352" alt="Screenshot 2024-05-03 at 11 09 29 AM" src="https://github.com/rustic-ai/ui-components/assets/111031789/41fad67d-669f-4a7c-8fe2-b4bbc84e4a6a">

#### After
<img width="376" alt="Screenshot 2024-05-03 at 11 11 32 AM" src="https://github.com/rustic-ai/ui-components/assets/111031789/fe05f0f5-6b5f-4111-aca6-50f5d7ef1e19">

### Timestamp
#### Before
<img width="437" alt="Screenshot 2024-05-03 at 11 08 54 AM" src="https://github.com/rustic-ai/ui-components/assets/111031789/29250c2b-a653-44b0-ab7b-00ad2762678b">

#### After
<img width="458" alt="Screenshot 2024-05-03 at 10 59 41 AM" src="https://github.com/rustic-ai/ui-components/assets/111031789/fe8d0c37-6351-427d-9205-e175fabaf7ab">

