### PR TITLE
fix: responsiveness of codeSnippet

### DIFF
--- a/src/components/codeSnippet/codeSnippet.css
+++ b/src/components/codeSnippet/codeSnippet.css
@@ -1,14 +1,13 @@
 .rustic-code-snippet {
-    border-radius: 16px 16px 4px 4px;
-    width: 100%;
-    height: 100%;
+  border-radius: 16px 16px 4px 4px;
+  max-width: calc(100vw - 100px);
 }
 
 .rustic-code-snippet p {
-    padding: 16px;
+  padding: 16px;
 }
 
 .rustic-code-snippet .cm-editor {
-    padding: 24px;
-    overflow-x: auto;
+  padding: 24px;
+  overflow-x: auto;
 }

--- a/src/components/codeSnippet/codeSnippet.stories.tsx
+++ b/src/components/codeSnippet/codeSnippet.stories.tsx
@@ -142,20 +142,11 @@ export const JS = {
   },
 }
 
-export const PythonInsideAParentContainer = {
+export const Python = {
   args: {
     code: pyCode,
     language: 'Python',
   },
-  decorators: [
-    (Story: StoryFn) => {
-      return (
-        <div style={{ width: '600px' }}>
-          <Story />
-        </div>
-      )
-    },
-  ],
 }
 
 export const PHP = {
@@ -200,7 +191,7 @@ export const HTMLInsideAParentContainer = {
   decorators: [
     (Story: StoryFn) => {
       return (
-        <div style={{ width: '600px' }}>
+        <div style={{ maxWidth: '600px' }}>
           <Story />
         </div>
       )


### PR DESCRIPTION
## Changes
- fix responsiveness of storybook compnent
- remove parent container from Python story
- make parent container of HTMLInsideAParentContainer story responsive

Addresses issue #108.

## Screenshots
### Before
<img width="399" alt="Screenshot 2024-05-06 at 9 42 25 AM" src="https://github.com/rustic-ai/ui-components/assets/111031789/dc9e9a7f-3b83-4173-8840-ef5447f67750">

### After
![snippet-after](https://github.com/rustic-ai/ui-components/assets/111031789/887e7d88-6a66-42ca-90a4-c0a1d940ae03)
