### PR TITLE
fix(table): responsiveness of table

### DIFF
--- a/src/components/table/table.css
+++ b/src/components/table/table.css
@@ -1,3 +1,7 @@
+.rustic-table {
+  max-width: calc(100vw - 100px);
+}
+
 .rustic-table .rustic-table-title {
   text-align: center;
 }


### PR DESCRIPTION
## Changes
- make `Table` component responsive and scroll on smaller widths

## Screenshots
### Before
<img width="377" alt="Screenshot 2024-05-06 at 10 03 01 AM" src="https://github.com/rustic-ai/ui-components/assets/111031789/6119c917-2a8b-4034-8563-f37687ea234d">

### After
![May-06-2024 12-48-39](https://github.com/rustic-ai/ui-components/assets/111031789/bdf41f66-636e-4124-8f56-e370a577da69)

