### PR TITLE
 feat(multipart): download files

### DIFF
--- a/src/components/multipart/multipart.cy.tsx
+++ b/src/components/multipart/multipart.cy.tsx
@@ -34,5 +34,17 @@ describe('Multipart Component', () => {
       cy.contains(props.text).should('not.exist')
       cy.get(filePreview).should('have.length', props.files.length)
     })
+
+    it(`renders download button for files with url on ${viewport} screen`, () => {
+      cy.mount(
+        <Multipart
+          files={[
+            { name: 'image.png', url: 'images/image-component-example.png' },
+          ]}
+        />
+      )
+
+      cy.get('[data-cy=download-button]').should('be.visible')
+    })
   })
 })

--- a/src/components/multipart/multipart.stories.tsx
+++ b/src/components/multipart/multipart.stories.tsx
@@ -49,3 +49,14 @@ export const FilesOnly = {
     files: fileList,
   },
 }
+
+export const FileWithURL = {
+  args: {
+    files: [
+      {
+        name: 'image.png',
+        url: 'images/image-component-example.png',
+      },
+    ],
+  },
+}

--- a/src/components/multipart/multipart.tsx
+++ b/src/components/multipart/multipart.tsx
@@ -1,17 +1,35 @@
 import '../../index.css'
 import './multipart.css'
 
+import IconButton from '@mui/material/IconButton'
+import Tooltip from '@mui/material/Tooltip'
 import Box from '@mui/system/Box'
 import React from 'react'
 
 import FilePreview from '../filePreview/filePreview'
+import Icon from '../icon'
 import Text from '../text/text'
 import type { MultipartData } from '../types'
 
 export default function Multipart(props: MultipartData) {
   function renderFiles() {
     const files = props.files.map((file, index) => {
-      return <FilePreview file={file} key={index} />
+      return (
+        <FilePreview file={file} key={index}>
+          {file.url && (
+            <Tooltip title="Download">
+              <IconButton
+                component="a"
+                href={file.url}
+                download={file.name}
+                data-cy="download-button"
+              >
+                <Icon name="download" />
+              </IconButton>
+            </Tooltip>
+          )}
+        </FilePreview>
+      )
     })
 
     return <Box className="rustic-files">{files}</Box>


### PR DESCRIPTION
## Changes
- allow download of files with urls

This PR assumes a URL is already present. When a user uploads files with the `MultimodalInput`, only file names are included in FileData. A discussion has begun in #131 regarding the best way to handle retrieving file urls upon upload.

## Screenshots
<img width="454" alt="Screenshot 2024-05-08 at 2 04 19 PM" src="https://github.com/rustic-ai/ui-components/assets/111031789/60455171-b724-4e5b-a50b-d893b2563296">