### PR TITLE
fix: update picture in picture tooltip wording

### DIFF
--- a/src/components/media/controls/mediaIconButton.tsx
+++ b/src/components/media/controls/mediaIconButton.tsx
@@ -13,8 +13,8 @@ interface MediaIconButtonProps {
     | 'replay'
     | 'volumeUp'
     | 'volumeOff'
-    | 'pictureInPicture'
-    | 'pictureInPictureExit'
+    | 'miniPlayer'
+    | 'miniPlayerExit'
     | 'fullscreen'
     | 'fullscreenExit'
     | 'captionsOn'
@@ -30,13 +30,13 @@ export function MediaIconButton(props: MediaIconButtonProps) {
     replay: { symbol: 'replay_10', label: 'replay ten seconds' },
     volumeUp: { symbol: 'volume_up', label: 'mute' },
     volumeOff: { symbol: 'volume_off', label: 'unmute' },
-    pictureInPicture: {
+    miniPlayer: {
       symbol: 'picture_in_picture',
-      label: 'picture in picture',
+      label: 'mini player',
     },
-    pictureInPictureExit: {
+    miniPlayerExit: {
       symbol: 'picture_in_picture_off',
-      label: 'exit picture in picture',
+      label: 'exit mini player',
     },
     fullscreen: { symbol: 'fullscreen', label: 'fullscreen' },
     fullscreenExit: { symbol: 'fullscreen_exit', label: 'exit fullscreen' },

--- a/src/components/media/controls/videoControls.tsx
+++ b/src/components/media/controls/videoControls.tsx
@@ -8,53 +8,47 @@ interface FullscreenButtonProps {
   onError: (errorMessage: string) => void
 }
 
-interface PictureInPictureButtonProps extends MediaControls {
+interface MiniPlayerButtonProps extends MediaControls {
   onError: (errorMessage: string) => void
 }
 
-export function PictureInPictureButton(props: PictureInPictureButtonProps) {
-  const [isPictureInPicture, setIsPictureInPicture] = useState(
+export function MiniPlayerButton(props: MiniPlayerButtonProps) {
+  const [isMiniPlayer, setIsMiniPlayer] = useState(
     !!document.pictureInPictureElement
   )
 
   const videoElement = props.mediaElement as HTMLVideoElement
 
-  const action = isPictureInPicture
-    ? 'pictureInPictureExit'
-    : 'pictureInPicture'
+  const action = isMiniPlayer ? 'miniPlayerExit' : 'miniPlayer'
 
-  function handlePictureInPicture() {
-    if (isPictureInPicture) {
+  function handleMiniPlayer() {
+    if (isMiniPlayer) {
       document
         .exitPictureInPicture()
         .then(() => {
-          setIsPictureInPicture(false)
+          setIsMiniPlayer(false)
         })
         .catch((error: DOMException) => {
-          props.onError(
-            `Failed to exit picture-in-picture mode. Error: ${error.message}`
-          )
+          props.onError(`Failed to exit mini player. Error: ${error.message}`)
         })
     } else {
       videoElement
         .requestPictureInPicture()
         .then(() => {
-          setIsPictureInPicture(true)
+          setIsMiniPlayer(true)
         })
         .catch((error: DOMException) => {
-          props.onError(
-            `Failed to enter picture-in-picture mode. Error: ${error.message}`
-          )
+          props.onError(`Failed to enter mini player. Error: ${error.message}`)
         })
     }
   }
 
   // State is updated by event listeners so that the icon is displayed correctly, even when users exit picture-in-picture without direct use of this toggle (e.g. exiting from the picture-in-picture window).
   videoElement.onleavepictureinpicture = function () {
-    setIsPictureInPicture(false)
+    setIsMiniPlayer(false)
   }
 
-  return <MediaIconButton onClick={handlePictureInPicture} action={action} />
+  return <MediaIconButton onClick={handleMiniPlayer} action={action} />
 }
 
 export function FullscreenButton(props: FullscreenButtonProps) {

--- a/src/components/media/video/video.cy.tsx
+++ b/src/components/media/video/video.cy.tsx
@@ -12,8 +12,8 @@ describe('Video', () => {
   const progressSlider = '[data-cy=progress-slider]'
   const pauseButton = '[data-cy=pause-button]'
   const playButton = '[data-cy=play-button]'
-  const pictureInPictureButton = '[data-cy=picture-in-picture-button]'
-  const pictureInPictureExitButton = '[data-cy=exit-picture-in-picture-button]'
+  const miniPlayerButton = '[data-cy=mini-player-button]'
+  const miniPlayerExitButton = '[data-cy=exit-mini-player-button]'
   const fullScreenEnterButton = '[data-cy=fullscreen-button]'
   const fullScreenExitButton = '[data-cy=exit-fullscreen-button]'
   const transcript = '[data-cy=transcript]'
@@ -178,7 +178,7 @@ describe('Video', () => {
       cy.get(playButton).should('exist')
       cy.get(transcriptToggle).should('exist')
       cy.get(fullScreenExitButton).should('exist')
-      cy.get(pictureInPictureButton).should('exist')
+      cy.get(miniPlayerButton).should('exist')
       cy.get(progressSlider).should('exist')
     })
   })
@@ -244,18 +244,18 @@ describe('Video', () => {
       cy.get(fullScreenEnterButton).should('exist')
       cy.document().its('fullscreenElement').should('not.exist')
     })
-    it('should toggle between picture-in-picture and normal mode when clicking the picture-in-picture button', () => {
-      cy.get(pictureInPictureButton).should('exist')
+    it('should toggle between mini player and normal mode when clicking the mini player button', () => {
+      cy.get(miniPlayerButton).should('exist')
       cy.hoverAndDisplay(controls)
-      cy.get(pictureInPictureButton).realClick()
+      cy.get(miniPlayerButton).realClick()
       cy.wait(1000)
-      cy.get(pictureInPictureExitButton).should('exist')
+      cy.get(miniPlayerExitButton).should('exist')
       cy.document().its('pictureInPictureElement').should('exist')
 
       cy.hoverAndDisplay(controls)
-      cy.get(pictureInPictureExitButton).click()
+      cy.get(miniPlayerExitButton).click()
       cy.wait(1000)
-      cy.get(pictureInPictureButton).should('exist')
+      cy.get(miniPlayerButton).should('exist')
       cy.document().its('pictureInPictureElement').should('not.exist')
     })
   })

--- a/src/components/media/video/video.tsx
+++ b/src/components/media/video/video.tsx
@@ -17,10 +17,7 @@ import {
   VolumeSettings,
 } from '../controls/commonControls'
 import { MediaIconButton } from '../controls/mediaIconButton'
-import {
-  FullscreenButton,
-  PictureInPictureButton,
-} from '../controls/videoControls'
+import { FullscreenButton, MiniPlayerButton } from '../controls/videoControls'
 import TimeIndicator from '../timeIndicator/timeIndicator'
 import Transcript from '../transcript/transcript'
 
@@ -120,7 +117,7 @@ export default function Video(props: VideoFormat) {
           </Typography>
           {isFullscreen && isMobile && (
             <Box>
-              <PictureInPictureButton
+              <MiniPlayerButton
                 mediaElement={videoRef.current}
                 onError={setControlErrorMessage}
               />
@@ -271,7 +268,7 @@ export default function Video(props: VideoFormat) {
 
               <Box className="rustic-video-bottom-controls-right">
                 {renderToggleTranscriptButton()}
-                <PictureInPictureButton
+                <MiniPlayerButton
                   mediaElement={videoRef.current}
                   onError={setControlErrorMessage}
                 />


### PR DESCRIPTION
## Changes
- update tooltip wording of "picture in picture" to "mini player"
- update naming throughout code for consistency

Addresses issue #113.

## Screenshots
### Before
![image](https://github.com/rustic-ai/ui-components/assets/111031789/a5bf2459-a026-4022-add5-36867e9cfe27)

### After
<img width="175" alt="Screenshot 2024-05-10 at 3 25 59 PM" src="https://github.com/rustic-ai/ui-components/assets/111031789/22739c3c-0051-49c7-bc86-5b16038271c6">
