### PR TITLE
fix: update overline text style

### DIFF
--- a/src/components/media/controls/commonControls.css
+++ b/src/components/media/controls/commonControls.css
@@ -53,7 +53,6 @@
 }
 
 .rustic-transcript-toggle span {
-  text-transform: none;
   line-height: 1.5;
 }
 

--- a/src/components/media/transcript/transcript.css
+++ b/src/components/media/transcript/transcript.css
@@ -14,7 +14,6 @@
 }
 
 .rustic-transcript-header span {
-  text-transform: none;
   padding-left: 14px;
   line-height: 1.5;
 }


### PR DESCRIPTION
## Changes
- update overline text styling in media components

Addresses issue #114.

## Screenshots
### Before
![image](https://github.com/rustic-ai/ui-components/assets/111031789/27abbb51-394e-4896-83ba-4d612076a344)

### After
<img width="766" alt="Screenshot 2024-05-12 at 8 52 06 AM" src="https://github.com/rustic-ai/ui-components/assets/111031789/49d6c06a-526a-4c35-9774-4c2d93c805fe">
