### PR TITLE
feat(navBar)!: update navBar to design

### DIFF
--- a/src/components/navBar/navBar.css
+++ b/src/components/navBar/navBar.css
@@ -1,7 +1,25 @@
-.rustic-nav-bar {
+.rustic-nav-bar-top {
   height: 72px;
   justify-content: space-between;
   padding: 16px;
+  gap: 16px;
+}
+
+.rustic-nav-bar-bottom {
+  position: fixed;
+  display: flex;
+  width: 100%;
+  height: 72px;
+  z-index: 1000;
+  bottom: 0;
+  left: 0;
+}
+
+.rustic-nav-bar-top-items {
+  display: flex;
+  gap: 16px;
+  width: 100%;
+  justify-content: flex-end;
 }
 
 .rustic-nav-bar-button {

--- a/src/components/navBar/navBar.stories.tsx
+++ b/src/components/navBar/navBar.stories.tsx
@@ -14,14 +14,6 @@ const meta: Meta<React.ComponentProps<typeof NavBar>> = {
   title: 'Rustic UI/Nav Bar/Nav Bar',
   component: NavBar,
   tags: ['autodocs'],
-  parameters: {
-    docs: {
-      description: {
-        component:
-          'The `NavBar` component provides a customizable navigation bar for web applications, offering both top and bottom navigation options. The top navigation bar can include a logo and various navigation items, while the bottom navigation bar is optimized for mobile devices.',
-      },
-    },
-  },
   decorators: [
     (Story: StoryFn) => {
       return (
@@ -126,14 +118,17 @@ const topNavItems = [
 const bottomNavItems = [
   {
     label: 'Conversations',
+    onClick: () => alert('Conversations clicked!'),
     icon: <Icon name="forum" />,
   },
   {
     label: 'New Conversation',
+    onClick: () => alert('New Conversation clicked!'),
     icon: <Icon name="add_circle_outline" />,
   },
   {
     label: 'Collections',
+    onClick: () => alert('Collections clicked!'),
     icon: <Icon name="bookmark" />,
   },
 ]

--- a/src/components/navBar/navBar.stories.tsx
+++ b/src/components/navBar/navBar.stories.tsx
@@ -1,12 +1,16 @@
 /* eslint-disable @typescript-eslint/no-empty-function */
+import { useTheme } from '@mui/material'
+import Avatar from '@mui/material/Avatar'
+import IconButton from '@mui/material/IconButton'
 import Typography from '@mui/material/Typography'
 import { Box } from '@mui/system'
+import type { Meta, StoryFn } from '@storybook/react'
 import React from 'react'
 
 import Icon from '../icon'
 import NavBar from './navBar'
 
-const meta = {
+const meta: Meta<React.ComponentProps<typeof NavBar>> = {
   title: 'Rustic UI/Nav Bar/Nav Bar',
   component: NavBar,
   tags: ['autodocs'],
@@ -14,7 +18,42 @@ const meta = {
     docs: {
       description: {
         component:
-          'The `NavBar` component provides a customizable navigation bar that can be used to create a consistent layout across web applications. It typically includes a logo or branding element in the center, along with buttons or icons for accessing various navigation options such as drawers or menus. Note: The icon buttons will only be shown on mobile and tablet screens.',
+          'The `NavBar` component provides a customizable navigation bar for web applications, offering both top and bottom navigation options. The top navigation bar can include a logo and various navigation items, while the bottom navigation bar is optimized for mobile devices.',
+      },
+    },
+  },
+  decorators: [
+    (Story: StoryFn) => {
+      return (
+        <div style={{ height: '300px' }}>
+          <Story />
+        </div>
+      )
+    },
+  ],
+}
+
+meta.argTypes = {
+  ...meta.argTypes,
+  topNavBarItems: {
+    table: {
+      type: {
+        summary: 'Array of TopNavBarItem.',
+        detail:
+          'Each TopNavBarItem has the following fields:\n' +
+          '  node: A ReactNode to be rendered.',
+      },
+    },
+  },
+  bottomNavBarItems: {
+    table: {
+      type: {
+        summary: 'Array of BottomNavBarItem.',
+        detail:
+          'Each BottomNavBarItem has the following fields:\n' +
+          '  label: String label of the item. \n' +
+          '  icon: ReactNode icon. \n' +
+          '  onClick: A function that is called when the item is clicked.\n',
       },
     },
   },
@@ -25,20 +64,111 @@ export default meta
 const Logo = () => {
   return (
     <Box sx={{ display: 'flex' }}>
-      <Typography sx={{ color: 'secondary.main' }}>RUSTIC&nbsp;</Typography>
-      <Typography>UI</Typography>
+      <Typography sx={{ color: 'secondary.main', fontWeight: 700 }}>
+        RUSTIC&nbsp;
+      </Typography>
+      <Typography sx={{ fontWeight: 700 }}>UI</Typography>
     </Box>
   )
 }
 
+const NotificationsIcon = () => {
+  const theme = useTheme()
+  return (
+    <IconButton color="primary" sx={{ p: 0 }}>
+      <Box
+        sx={{
+          width: '35px',
+          height: '35px',
+          borderRadius: '50%',
+          display: 'flex',
+          justifyContent: 'center',
+          alignItems: 'center',
+          border: `1px solid ${theme.palette.divider}`,
+        }}
+      >
+        <Icon name="notifications" />
+      </Box>
+    </IconButton>
+  )
+}
+
+const ProfileIcon = () => {
+  const theme = useTheme()
+  return (
+    <IconButton sx={{ p: 0 }}>
+      <Avatar
+        sx={{
+          width: '35px',
+          height: '35px',
+          borderRadius: '50%',
+          display: 'flex',
+          justifyContent: 'center',
+          alignItems: 'center',
+          border: `1px solid ${theme.palette.divider}`,
+        }}
+      >
+        RU
+      </Avatar>
+    </IconButton>
+  )
+}
+
+const topNavItems = [
+  {
+    node: <NotificationsIcon />,
+  },
+  {
+    node: <ProfileIcon />,
+  },
+]
+
+const bottomNavItems = [
+  {
+    label: 'Conversations',
+    icon: <Icon name="forum" />,
+  },
+  {
+    label: 'New Conversation',
+    icon: <Icon name="add_circle_outline" />,
+  },
+  {
+    label: 'Collections',
+    icon: <Icon name="bookmark" />,
+  },
+]
+
 export const Default = {
   args: {
     logo: <Logo />,
-    leftDrawerIcon: <Icon name="chat" />,
-    rightDrawerIcon: <Icon name="bookmark" />,
-    leftDrawerAriaLabel: 'Open Left Drawer',
-    rightDrawerAriaLabel: 'Open Right Drawer',
-    handleLeftDrawerToggle: () => {},
-    handleRightDrawerToggle: () => {},
+    topNavBarItems: topNavItems,
+    bottomNavBarItems: bottomNavItems,
+  },
+}
+
+export const NoBottomNav = {
+  args: {
+    logo: <Logo />,
+    topNavBarItems: topNavItems,
+  },
+}
+
+export const NoTopNav = {
+  args: {
+    bottomNavBarItems: bottomNavItems,
+  },
+}
+
+export const NoTopNavItems = {
+  args: {
+    logo: <Logo />,
+    bottomNavBarItems: bottomNavItems,
+  },
+}
+
+export const NoLogo = {
+  args: {
+    topNavBarItems: topNavItems,
+    bottomNavBarItems: bottomNavItems,
   },
 }

--- a/src/components/navBar/navBar.tsx
+++ b/src/components/navBar/navBar.tsx
@@ -1,66 +1,101 @@
 import './navBar.css'
 
+import { useMediaQuery } from '@mui/material'
 import AppBar from '@mui/material/AppBar'
-import IconButton from '@mui/material/IconButton'
+import BottomNavigation from '@mui/material/BottomNavigation'
+import BottomNavigationAction from '@mui/material/BottomNavigationAction'
+import Box from '@mui/material/Box'
 import { useTheme } from '@mui/material/styles'
 import Toolbar from '@mui/material/Toolbar'
 import type { ReactNode } from 'react'
 import React from 'react'
 
-interface NavBarProps {
-  /** Desktop version: Logo is displayed in the top left corner. Tablet and mobile versions: position will be different if you add the drawer icons. */
-  logo: ReactNode
-  /** Icon for the button that opens/closes the left drawer. (Will only be shown in mobile and tablet versions.) */
-  leftDrawerIcon?: ReactNode
-  /** Icon for the button that opens/closes the right drawer. (Will only be shown in mobile and tablet versions.)*/
-  rightDrawerIcon?: ReactNode
-  /** Aria label for the left drawer button. */
-  leftDrawerAriaLabel?: string
-  /** Aria label for the right drawer button. */
-  rightDrawerAriaLabel?: string
-  /** Function for toggling the open/closed state of the left drawer. */
-  handleLeftDrawerToggle?: () => void
-  /** Function for toggling the open/closed state of the right drawer. */
-  handleRightDrawerToggle?: () => void
+export interface BottomNavBarItem {
+  label: string
+  onClick: () => void
+  icon: ReactNode
+}
+
+export interface TopNavBarItem {
+  node: ReactNode
+}
+
+export interface NavBarProps {
+  /**
+   * The logo to be displayed in the navigation bar.
+   */
+  logo?: ReactNode
+
+  /**
+   * An array of items to be displayed in the top navigation bar. We recommend at most 3 items.
+   */
+  topNavBarItems?: TopNavBarItem[]
+
+  /**
+   * An array of items to be displayed in the bottom navigation bar on mobile devices. We recommend at most 3 items.
+   */
+  bottomNavBarItems?: BottomNavBarItem[]
 }
 
 const NavBar = (props: NavBarProps) => {
   const theme = useTheme()
+  const isMobile = useMediaQuery(theme.breakpoints.down('md'))
+
+  const topNavItems = props.topNavBarItems?.map((item, index) => (
+    <React.Fragment key={index}>{item.node}</React.Fragment>
+  ))
+
+  const bottomNavItems = props.bottomNavBarItems?.map((item) => (
+    <BottomNavigationAction
+      key={item.label}
+      label={item.label}
+      value={item.label}
+      icon={item.icon}
+    />
+  ))
+
   return (
-    <AppBar
-      position="fixed"
-      color="inherit"
-      sx={{ borderBottom: `1px solid ${theme.palette.divider}` }}
-      data-cy="nav-bar"
-    >
-      <Toolbar className="rustic-nav-bar">
-        {props.leftDrawerIcon && (
-          <IconButton
-            color="inherit"
-            aria-label={props.leftDrawerAriaLabel}
-            edge="start"
-            onClick={props.handleLeftDrawerToggle}
-            className="rustic-nav-bar-button"
-            data-cy="left-drawer-button"
+    <>
+      {(props.logo ||
+        (props.topNavBarItems && props.topNavBarItems.length > 0)) && (
+        <AppBar
+          position="fixed"
+          color="inherit"
+          sx={{ borderBottom: `1px solid ${theme.palette.divider}` }}
+          data-cy="nav-bar"
+        >
+          <Toolbar className="rustic-nav-bar-top" data-cy="nav-bar-top">
+            {props.logo}
+
+            {props.topNavBarItems && props.topNavBarItems.length > 0 && (
+              <Box
+                className="rustic-nav-bar-top-items"
+                data-cy="nav-bar-top-items"
+              >
+                {topNavItems}
+              </Box>
+            )}
+          </Toolbar>
+        </AppBar>
+      )}
+      {isMobile &&
+        props.bottomNavBarItems &&
+        props.bottomNavBarItems.length > 0 && (
+          <BottomNavigation
+            showLabels
+            className="rustic-nav-bar-bottom"
+            onChange={(event, newValue) => {
+              props.bottomNavBarItems
+                ?.find((item) => item.label === newValue)!
+                .onClick()
+            }}
+            sx={{ borderTop: `1px solid ${theme.palette.divider}` }}
+            data-cy="nav-bar-bottom"
           >
-            {props.leftDrawerIcon}
-          </IconButton>
+            {bottomNavItems}
+          </BottomNavigation>
         )}
-        {props.logo}
-        {props.rightDrawerIcon && (
-          <IconButton
-            color="inherit"
-            aria-label={props.rightDrawerAriaLabel}
-            edge="end"
-            onClick={props.handleRightDrawerToggle}
-            className="rustic-nav-bar-button"
-            data-cy="right-drawer-button"
-          >
-            {props.rightDrawerIcon}
-          </IconButton>
-        )}
-      </Toolbar>
-    </AppBar>
+    </>
   )
 }
 

--- a/src/components/navBar/navBar.tsx
+++ b/src/components/navBar/navBar.tsx
@@ -21,22 +21,19 @@ export interface TopNavBarItem {
 }
 
 export interface NavBarProps {
-  /**
-   * The logo to be displayed in the navigation bar.
-   */
+  /** The logo to be displayed in the navigation bar. */
   logo?: ReactNode
 
-  /**
-   * An array of items to be displayed in the top navigation bar. We recommend at most 3 items.
-   */
+  /** An array of items to be displayed in the top navigation bar. We recommend at most 3 items. */
   topNavBarItems?: TopNavBarItem[]
 
-  /**
-   * An array of items to be displayed in the bottom navigation bar on mobile devices. We recommend at most 3 items.
-   */
+  /** An array of items to be displayed in the bottom navigation bar on mobile devices. We recommend at most 3 items. */
   bottomNavBarItems?: BottomNavBarItem[]
 }
 
+/**
+The `NavBar` component provides a customizable navigation bar for web applications, offering both top and bottom navigation options. The top navigation bar can include a logo and various navigation items, while the bottom navigation bar is optimized for mobile devices.
+ */
 const NavBar = (props: NavBarProps) => {
   const theme = useTheme()
   const isMobile = useMediaQuery(theme.breakpoints.down('md'))
@@ -53,6 +50,10 @@ const NavBar = (props: NavBarProps) => {
       icon={item.icon}
     />
   ))
+
+  function handleOnClick(event: React.SyntheticEvent, newValue: string) {
+    props.bottomNavBarItems?.find((item) => item.label === newValue)!.onClick()
+  }
 
   return (
     <>
@@ -84,11 +85,7 @@ const NavBar = (props: NavBarProps) => {
           <BottomNavigation
             showLabels
             className="rustic-nav-bar-bottom"
-            onChange={(event, newValue) => {
-              props.bottomNavBarItems
-                ?.find((item) => item.label === newValue)!
-                .onClick()
-            }}
+            onChange={handleOnClick}
             sx={{ borderTop: `1px solid ${theme.palette.divider}` }}
             data-cy="nav-bar-bottom"
           >


### PR DESCRIPTION
BREAKING CHANGE: new navBar props and classnames

## Changes
- update `NavBar` component to match design
- include bottom nav on mobile

The top `topNavBarItems` we're made to be flexible with any `ReactNode` while the `bottomNavBarItems` explicitly define a label, icon, and onClick for each item. I wanted to get some insight from others on whether this is a suitable way of handling this based on the designs.

## Screenshots
### Design
#### Desktop
<img width="1649" alt="Screenshot 2024-05-13 at 5 07 54 PM" src="https://github.com/rustic-ai/ui-components/assets/111031789/7e789700-25ca-4f32-b8bf-3289de2715c9">

#### Mobile
<img width="587" alt="Screenshot 2024-05-13 at 5 07 21 PM" src="https://github.com/rustic-ai/ui-components/assets/111031789/f3a16541-cda7-49c9-8f3e-0d8a1658118e">

### Before
#### Desktop
<img width="672" alt="Screenshot 2024-05-13 at 5 05 41 PM" src="https://github.com/rustic-ai/ui-components/assets/111031789/2c31a7b8-2cd1-4d38-bc72-5d9b2553f32c">

#### Mobile
<img width="345" alt="Screenshot 2024-05-13 at 5 06 03 PM" src="https://github.com/rustic-ai/ui-components/assets/111031789/ea20efec-13ff-45da-9d34-d54c49cabf4e">

### After
#### Desktop
<img width="672" alt="Screenshot 2024-05-13 at 5 05 21 PM" src="https://github.com/rustic-ai/ui-components/assets/111031789/a47e29eb-453f-4c2b-927f-e925328163c7">
<img width="684" alt="Screenshot 2024-05-13 at 4 50 36 PM" src="https://github.com/rustic-ai/ui-components/assets/111031789/816e534a-4d40-43f0-aede-3c6aa8b11314">
<img width="684" alt="Screenshot 2024-05-13 at 4 50 50 PM" src="https://github.com/rustic-ai/ui-components/assets/111031789/2c53f7ac-b3e6-4d5b-ab34-f320a3ea3c71">

#### Mobile
<img width="339" alt="Screenshot 2024-05-13 at 4 51 24 PM" src="https://github.com/rustic-ai/ui-components/assets/111031789/fed267c2-d3fc-4c87-ab9d-c3a501683111">
<img width="339" alt="Screenshot 2024-05-13 at 4 51 38 PM" src="https://github.com/rustic-ai/ui-components/assets/111031789/728e9e01-8378-42ae-9a70-58156badf659">

#### Dark mode
<img width="358" alt="Screenshot 2024-05-13 at 5 09 20 PM" src="https://github.com/rustic-ai/ui-components/assets/111031789/2505c2d4-3dd3-47b7-a344-e7cca3cf0d22">
<img width="358" alt="Screenshot 2024-05-13 at 5 09 20 PM" src="https://github.com/rustic-ai/ui-components/assets/111031789/2505c2d4-3dd3-47b7-a344-e7cca3cf0d22">
