### PR TITLE
fix: improve scrolling behaviour

### DIFF
--- a/src/components/messageCanvas/messageCanvas.tsx
+++ b/src/components/messageCanvas/messageCanvas.tsx
@@ -3,7 +3,7 @@ import './messageCanvas.css'
 import Card from '@mui/material/Card'
 import Typography from '@mui/material/Typography'
 import Box from '@mui/system/Box'
-import React, { type ReactNode } from 'react'
+import React, { forwardRef, type ReactNode } from 'react'
 
 import Timestamp from '../timestamp/timestamp'
 import type { ThreadableMessage } from '../types'
@@ -32,12 +32,16 @@ export interface MessageCanvasProps extends MessageContainerProps {
  It provides a structured layout for rendering message content along with sender information and timestamp details.
  This component is designed to encapsulate individual message items and facilitate consistent rendering of messages within an application.
  */
-export default function MessageCanvas(props: MessageCanvasProps) {
+function MessageCanvasElement(
+  props: MessageCanvasProps,
+  ref: React.Ref<HTMLDivElement>
+) {
   return (
     <Box
       id={props.message.id}
       className="rustic-message-canvas"
       data-cy="message-canvas"
+      ref={ref}
     >
       <Box className="rustic-sender-info">
         {props.getProfileComponent && props.getProfileComponent(props.message)}
@@ -70,3 +74,6 @@ export default function MessageCanvas(props: MessageCanvasProps) {
     </Box>
   )
 }
+
+const MessageCanvas = forwardRef(MessageCanvasElement)
+export default MessageCanvas

--- a/src/components/messageSpace/messageSpace.tsx
+++ b/src/components/messageSpace/messageSpace.tsx
@@ -34,7 +34,6 @@ function usePrevious(value: number) {
 export default function MessageSpace(props: MessageSpaceProps) {
   const scrollEndRef = useRef<HTMLDivElement>(null)
   const containerRef = useRef<HTMLDivElement>(null)
-  const lastMessageRef = useRef<HTMLDivElement>(null)
   const timeoutRef = useRef<NodeJS.Timeout>()
 
   const [isScrolledToBottom, setIsScrolledToBottom] = useState(false)
@@ -114,14 +113,24 @@ export default function MessageSpace(props: MessageSpaceProps) {
   function scrollToLastMessage() {
     if (getVideoStatus()) {
       const container = containerRef.current
-      const lastMessage = lastMessageRef.current
+      const childrenComponent = container && container.children
+      // scroll end div is also accounted as children component
+      const minimumChildrenLength = 2
       const messageMargin = 32
-      if (lastMessage && container) {
-        // Use setTimeout to delay smooth scrolling
-        setTimeout(() => {
-          container.scrollTop =
-            container.scrollHeight - lastMessage.clientHeight - messageMargin
-        }, 0)
+      if (
+        childrenComponent &&
+        childrenComponent.length >= minimumChildrenLength
+      ) {
+        const lastMessage =
+          childrenComponent[childrenComponent.length - minimumChildrenLength]
+
+        if (lastMessage) {
+          // Use setTimeout to delay smooth scrolling
+          setTimeout(() => {
+            container.scrollTop =
+              container.scrollHeight - lastMessage.clientHeight - messageMargin
+          }, 0)
+        }
       }
     } else {
       setTimeout(scrollToLastMessage, 1)
@@ -147,23 +156,19 @@ export default function MessageSpace(props: MessageSpaceProps) {
     >
       {props.messages &&
         props.messages.length > 0 &&
-        props.messages.map((message, index) => {
+        props.messages.map((message) => {
           return (
-            <div
+            <MessageCanvas
               key={message.id}
-              ref={index === props.messages!.length - 1 ? lastMessageRef : null}
+              message={message}
+              getActionsComponent={props.getActionsComponent}
+              getProfileComponent={props.getProfileComponent}
             >
-              <MessageCanvas
+              <ElementRenderer
                 message={message}
-                getActionsComponent={props.getActionsComponent}
-                getProfileComponent={props.getProfileComponent}
-              >
-                <ElementRenderer
-                  message={message}
-                  supportedElements={props.supportedElements}
-                />
-              </MessageCanvas>
-            </div>
+                supportedElements={props.supportedElements}
+              />
+            </MessageCanvas>
           )
         })}
       <div ref={scrollEndRef}></div>

--- a/src/components/messageSpace/messageSpace.tsx
+++ b/src/components/messageSpace/messageSpace.tsx
@@ -116,7 +116,6 @@ export default function MessageSpace(props: MessageSpaceProps) {
       const childrenComponent = container && container.children
       // scroll end div is also accounted as children component
       const minimumChildrenLength = 2
-      const messageMargin = 32
       if (
         childrenComponent &&
         childrenComponent.length >= minimumChildrenLength
@@ -127,8 +126,7 @@ export default function MessageSpace(props: MessageSpaceProps) {
         if (lastMessage) {
           // Use setTimeout to delay smooth scrolling
           setTimeout(() => {
-            container.scrollTop =
-              container.scrollHeight - lastMessage.clientHeight - messageMargin
+            lastMessage.scrollIntoView({ block: 'start', inline: 'nearest' })
           }, 0)
         }
       }


### PR DESCRIPTION
## Change
- When new messages come in and it's at the bottom of page, the top part of message will be shown if the message is super long. For streamingMarkdown and streamingText, only the initial part of message will be shown. User needs to click scroll button to read more.
- Avoid showing scroll button when it's scrolling (was flaky before)

## Before
![May-16-2024 10-42-05](https://github.com/rustic-ai/ui-components/assets/103023797/15f560b2-3692-41e5-807f-3008186bbd0c)
![May-16-2024 10-46-14](https://github.com/rustic-ai/ui-components/assets/103023797/922b2c08-a668-4b2e-9e5f-49cb9482c07c)

## After
![May-16-2024 10-36-58](https://github.com/rustic-ai/ui-components/assets/103023797/a48b7b5a-76cd-435c-ba8e-78f3de830fef)
![May-16-2024 10-38-08](https://github.com/rustic-ai/ui-components/assets/103023797/b8e6be66-6fcb-4bda-8680-2f62ff020d29)
![May-16-2024 10-47-50](https://github.com/rustic-ai/ui-components/assets/103023797/c8f164eb-8d50-448b-af12-f7e4668daf32)
