### PR TITLE
fix: override button text transform

### DIFF
--- a/src/components/menu/popoverMenu.css
+++ b/src/components/menu/popoverMenu.css
@@ -7,10 +7,6 @@
   padding-block: 8px;
 }
 
-.rustic-popover-menu-button {
-  text-transform: none;
-}
-
 .rustic-popover-menu-item-icon {
   display: flex;
 }

--- a/src/rusticTheme.ts
+++ b/src/rusticTheme.ts
@@ -1,5 +1,5 @@
 /* eslint-disable no-magic-numbers */
-import type { Shadows } from '@mui/material/styles'
+import type { Components, Shadows } from '@mui/material/styles'
 import { createTheme, responsiveFontSizes } from '@mui/material/styles'
 
 const whiteColor = '#FFFFFF'
@@ -137,6 +137,16 @@ const baseTheme = createTheme({
   ] as Shadows,
 })
 
+const sharedComponents: Components = {
+  MuiButton: {
+    styleOverrides: {
+      root: {
+        textTransform: 'none',
+      },
+    },
+  },
+}
+
 const lightModePrimaryMainColor = '#3D3834'
 
 let rusticLightTheme = createTheme({
@@ -181,6 +191,7 @@ let rusticLightTheme = createTheme({
         },
       },
     },
+    ...sharedComponents,
   },
 })
 
@@ -228,6 +239,7 @@ let rusticDarkTheme = createTheme({
         },
       },
     },
+    ...sharedComponents,
   },
 })
 

--- a/src/rusticTheme.ts
+++ b/src/rusticTheme.ts
@@ -1,6 +1,7 @@
 /* eslint-disable no-magic-numbers */
-import type { Components, Shadows } from '@mui/material/styles'
+import type { Shadows } from '@mui/material/styles'
 import { createTheme, responsiveFontSizes } from '@mui/material/styles'
+import { deepmerge } from '@mui/utils'
 
 const whiteColor = '#FFFFFF'
 const SecondaryMainColor = '#FF6928'
@@ -135,113 +136,112 @@ const baseTheme = createTheme({
       }
     }),
   ] as Shadows,
-})
-
-const sharedComponents: Components = {
-  MuiButton: {
-    styleOverrides: {
-      root: {
-        textTransform: 'none',
+  components: {
+    MuiButton: {
+      styleOverrides: {
+        root: {
+          textTransform: 'capitalize',
+        },
       },
     },
   },
-}
+})
 
 const lightModePrimaryMainColor = '#3D3834'
 
-let rusticLightTheme = createTheme({
-  ...baseTheme,
-  palette: {
-    mode: 'light',
-    divider: dividerColor,
-    text: {
-      primary: '#1E0C04',
-      secondary: '#4E443F',
-      disabled: '#9C9795',
+let rusticLightTheme = createTheme(
+  deepmerge(baseTheme, {
+    palette: {
+      mode: 'light',
+      divider: dividerColor,
+      text: {
+        primary: '#1E0C04',
+        secondary: '#4E443F',
+        disabled: '#9C9795',
+      },
+      primary: {
+        main: lightModePrimaryMainColor,
+        dark: '#2D2825',
+        light: '#716865',
+      },
+      secondary: {
+        main: SecondaryMainColor,
+        light: '#FFDBCC',
+        dark: SecondaryDarkColor,
+      },
+      background: {
+        default: '#F7F6F5',
+        paper: whiteColor,
+      },
+      action: {
+        active: actionActiveColor,
+        hover: '#EFEAEA',
+        selected: actionSelectedColor,
+        disabledBackground: actionDisabledBackgroundColor,
+        focus: actionFocusColor,
+        disabled: actionDisabledColor,
+      },
     },
-    primary: {
-      main: lightModePrimaryMainColor,
-      dark: '#2D2825',
-      light: '#716865',
-    },
-    secondary: {
-      main: SecondaryMainColor,
-      light: '#FFDBCC',
-      dark: SecondaryDarkColor,
-    },
-    background: {
-      default: '#F7F6F5',
-      paper: whiteColor,
-    },
-    action: {
-      active: actionActiveColor,
-      hover: '#EFEAEA',
-      selected: actionSelectedColor,
-      disabledBackground: actionDisabledBackgroundColor,
-      focus: actionFocusColor,
-      disabled: actionDisabledColor,
-    },
-  },
-  components: {
-    MuiTooltip: {
-      styleOverrides: {
-        tooltip: {
-          backgroundColor: lightModePrimaryMainColor,
-          color: whiteColor,
+    components: {
+      MuiTooltip: {
+        styleOverrides: {
+          tooltip: {
+            backgroundColor: lightModePrimaryMainColor,
+            color: whiteColor,
+          },
         },
       },
     },
-    ...sharedComponents,
-  },
-})
+  })
+)
 
 const darkModePaperColor = '#2F2F2F'
 const darkModePrimaryMainColor = '#FFFCFB'
-let rusticDarkTheme = createTheme({
-  ...baseTheme,
-  palette: {
-    mode: 'dark',
-    divider: dividerColor,
-    primary: {
-      main: darkModePrimaryMainColor,
-      dark: SecondaryDarkColor,
-      light: '#FFDBCC',
+let rusticDarkTheme = createTheme(
+  deepmerge(baseTheme, {
+    palette: {
+      mode: 'dark',
+      divider: dividerColor,
+      primary: {
+        main: darkModePrimaryMainColor,
+        dark: SecondaryDarkColor,
+        light: '#FFDBCC',
+      },
+      secondary: {
+        main: SecondaryMainColor,
+        light: '#FFA983',
+        dark: SecondaryDarkColor,
+      },
+      background: {
+        default: '#040404',
+        paper: darkModePaperColor,
+      },
+      text: {
+        primary: whiteColor,
+        secondary: '#EBEBEB',
+        disabled: '#C1C1C1',
+      },
+      action: {
+        active: actionActiveColor,
+        hover: '#9A9A9A',
+        selected: actionSelectedColor,
+        focus: actionFocusColor,
+        disabledBackground: actionDisabledBackgroundColor,
+        disabled: actionDisabledColor,
+      },
     },
-    secondary: {
-      main: SecondaryMainColor,
-      light: '#FFA983',
-      dark: SecondaryDarkColor,
-    },
-    background: {
-      default: '#040404',
-      paper: darkModePaperColor,
-    },
-    text: {
-      primary: whiteColor,
-      secondary: '#EBEBEB',
-      disabled: '#C1C1C1',
-    },
-    action: {
-      active: actionActiveColor,
-      hover: '#9A9A9A',
-      selected: actionSelectedColor,
-      focus: actionFocusColor,
-      disabledBackground: actionDisabledBackgroundColor,
-      disabled: actionDisabledColor,
-    },
-  },
-  components: {
-    MuiTooltip: {
-      styleOverrides: {
-        tooltip: {
-          backgroundColor: darkModePrimaryMainColor,
-          color: darkModePaperColor,
+    components: {
+      MuiTooltip: {
+        styleOverrides: {
+          tooltip: {
+            backgroundColor: darkModePrimaryMainColor,
+            color: darkModePaperColor,
+          },
         },
       },
     },
-    ...sharedComponents,
-  },
-})
+  })
+)
 
 rusticLightTheme = responsiveFontSizes(rusticLightTheme)
 rusticDarkTheme = responsiveFontSizes(rusticDarkTheme)


### PR DESCRIPTION
## Changes
- override `MuiButton` text transform
    - none of the Figma designs use buttons with all uppercase, which is the MUI default for buttons
- remove text transform styling from `PopoverMenu` css

## Screenshots
### Before
<img width="398" alt="Screenshot 2024-05-17 at 3 53 26 PM" src="https://github.com/rustic-ai/ui-components/assets/111031789/e3bc3d7a-7d7d-454f-a98a-96d29815f3d2">
<img width="398" alt="Screenshot 2024-05-17 at 3 53 48 PM" src="https://github.com/rustic-ai/ui-components/assets/111031789/72abaa48-5e7c-4180-a201-36e48f814890">

### After
<img width="398" alt="Screenshot 2024-05-17 at 3 52 42 PM" src="https://github.com/rustic-ai/ui-components/assets/111031789/fe2b932c-136f-483e-b634-1fd68b1c19fd">
<img width="398" alt="Screenshot 2024-05-17 at 3 52 59 PM" src="https://github.com/rustic-ai/ui-components/assets/111031789/33ddf10c-e834-4e1b-93bb-b0148a1c14bb">

### PopoverMenu with text (no change)
<img width="398" alt="Screenshot 2024-05-17 at 4 04 28 PM" src="https://github.com/rustic-ai/ui-components/assets/111031789/397dfd0b-2f59-49f8-a4aa-2db007db4a3a">

