### PR TITLE
fix: use aspect ratio instead of fixed height

### DIFF
--- a/src/components/map/openLayersMap.css
+++ b/src/components/map/openLayersMap.css
@@ -1,6 +1,6 @@
 .rustic-open-layers-map-canvas {
-  height: 200px;
   width: 100%;
+  aspect-ratio: 16/9;
 }
 
 span.rustic-open-layers-map-marker {


### PR DESCRIPTION
resolves #109 

## Change 
- Use aspect ratio instead of fixed height

Note: In the issue, Renata mentioned the height should be 403px. I've confirmed with her that it's okay to use the aspect ratio.

## Before
<img width="1047" alt="Screenshot 2024-05-17 at 5 29 10 PM" src="https://github.com/rustic-ai/ui-components/assets/103023797/96139e2e-89a8-4643-87fb-d27e2e73295f">

## After
<img width="1018" alt="Screenshot 2024-05-17 at 5 29 23 PM" src="https://github.com/rustic-ai/ui-components/assets/103023797/66a51029-91ed-4714-a97c-d4b09daedb80">
