### PR TITLE
fix: update tooltip styling

### DIFF
--- a/src/components/visualization/vegaLiteViz/vegaLiteViz.css
+++ b/src/components/visualization/vegaLiteViz/vegaLiteViz.css
@@ -7,3 +7,12 @@
 .rustic-vega-lite {
   flex: 1;
 }
+
+#rustic-vega-lite-tooltip {
+  position: fixed;
+  visibility: hidden;
+}
+
+#rustic-vega-lite-tooltip.visible {
+  visibility: visible;
+}

--- a/src/components/visualization/vegaLiteViz/vegaLiteViz.tsx
+++ b/src/components/visualization/vegaLiteViz/vegaLiteViz.tsx
@@ -5,6 +5,7 @@ import Typography from '@mui/material/Typography'
 import Stack from '@mui/system/Stack'
 import useTheme from '@mui/system/useTheme'
 import React, { useEffect, useRef, useState } from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
 import { default as VegaEmbed } from 'vega-embed'
 
 import type { VegaLiteData } from '../../types'
@@ -16,24 +17,32 @@ function VegaLiteViz(props: VegaLiteData) {
   const rusticTheme: Theme = useTheme()
   const isDarkTheme = rusticTheme.palette.mode === 'dark'
   const defaultFont = rusticTheme.typography.fontFamily
-  const tooltipBackgroundColor = rusticTheme.palette.primary.main
-  const tooltipTextColor = rusticTheme.palette.background.paper
-  const borderRadius = rusticTheme.shape.borderRadius
-  const tooltipFontSize = rusticTheme.typography.caption.fontSize
-  const tooltipFontWeight = rusticTheme.typography.caption.fontWeight
+  const tooltipStyle = {
+    backgroundColor: rusticTheme.palette.primary.main,
+    color: rusticTheme.palette.background.paper,
+    borderRadius: rusticTheme.shape.borderRadius + 'px',
+    padding: '4px 8px',
+    fontSize: rusticTheme.typography.caption.fontSize,
+    fontFamily: defaultFont,
+    fontWeight: rusticTheme.typography.caption.fontWeight,
+  }
+
   const tooltipOptions = {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    formatTooltip: (value: any, sanitize: (value: any) => string) => {
-      let tooltipContent = `<div class='rustic-vega-lite-tooltip-content' style="background-color: ${tooltipBackgroundColor}; color: ${tooltipTextColor};border-radius: ${borderRadius}px; padding: 4px 8px; font-size: ${tooltipFontSize}; font-family: ${defaultFont}; font-weight: ${tooltipFontWeight};">`
-
-      for (const key in value) {
-        if (Object.prototype.hasOwnProperty.call(value, key)) {
-          tooltipContent += `<strong>${sanitize(key)}:</strong> ${sanitize(value[key])}<br />`
-        }
-      }
-      tooltipContent += '</div>'
-      return tooltipContent
-    },
+    formatTooltip: (value: any, sanitize: (value: any) => string) =>
+      renderToStaticMarkup(
+        <div
+          role="tooltip"
+          className="rustic-vega-lite-tooltip-content"
+          style={tooltipStyle}
+        >
+          {Object.entries(value).map(([key, val]) => (
+            <div key={key}>
+              <strong>{sanitize(key)}:</strong> {sanitize(val)}
+            </div>
+          ))}
+        </div>
+      ),
     disableDefaultStyle: true,
     //need this id to hide and show tooltip
     id: 'rustic-vega-lite-tooltip',

--- a/src/components/visualization/vegaLiteViz/vegaLiteViz.tsx
+++ b/src/components/visualization/vegaLiteViz/vegaLiteViz.tsx
@@ -16,6 +16,28 @@ function VegaLiteViz(props: VegaLiteData) {
   const rusticTheme: Theme = useTheme()
   const isDarkTheme = rusticTheme.palette.mode === 'dark'
   const defaultFont = rusticTheme.typography.fontFamily
+  const tooltipBackgroundColor = rusticTheme.palette.primary.main
+  const tooltipTextColor = rusticTheme.palette.background.paper
+  const borderRadius = rusticTheme.shape.borderRadius
+  const tooltipFontSize = rusticTheme.typography.caption.fontSize
+  const tooltipFontWeight = rusticTheme.typography.caption.fontWeight
+  const tooltipOptions = {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    formatTooltip: (value: any, sanitize: (value: any) => string) => {
+      let tooltipContent = `<div class='rustic-vega-lite-tooltip-content' style="background-color: ${tooltipBackgroundColor}; color: ${tooltipTextColor};border-radius: ${borderRadius}px; padding: 4px 8px; font-size: ${tooltipFontSize}; font-family: ${defaultFont}; font-weight: ${tooltipFontWeight};">`
+
+      for (const key in value) {
+        if (Object.prototype.hasOwnProperty.call(value, key)) {
+          tooltipContent += `<strong>${sanitize(key)}:</strong> ${sanitize(value[key])}<br />`
+        }
+      }
+      tooltipContent += '</div>'
+      return tooltipContent
+    },
+    disableDefaultStyle: true,
+    //need this id to hide and show tooltip
+    id: 'rustic-vega-lite-tooltip',
+  }
 
   function renderChart() {
     if (chartRef.current && props.spec) {
@@ -23,6 +45,7 @@ function VegaLiteViz(props: VegaLiteData) {
         config: { font: defaultFont },
         ...props.options,
         theme: isDarkTheme ? props.theme?.dark : props.theme?.light,
+        tooltip: tooltipOptions,
       }
 
       if (!props.options?.config?.font) {


### PR DESCRIPTION
## Change
- update tooltip styling

(I didn't found a way to get MUI tooltip padding. It's not set in our theme file and I'm not sure how to get the default theme padding)
## Before 
<img width="330" alt="Screenshot 2024-05-23 at 4 18 17 PM" src="https://github.com/rustic-ai/ui-components/assets/103023797/d96bebc6-9cf7-486a-b2ce-87110cb4121b">

## After


![Screenshot 2024-05-26 at 3 02 21 PM](https://github.com/rustic-ai/ui-components/assets/103023797/61d8b106-36fc-4728-9fcc-3286f7d87ab5)
![Screenshot 2024-05-26 at 3 02 28 PM](https://github.com/rustic-ai/ui-components/assets/103023797/437e9904-4db2-45b5-b99a-ef5a6f063334)
