### PR TITLE
fix: make media icon buttons larger

### DIFF
--- a/src/components/icon/icon.css
+++ b/src/components/icon/icon.css
@@ -1,0 +1,3 @@
+span.rustic-icon-large {
+  font-size: 32px;
+}

--- a/src/components/icon/icon.tsx
+++ b/src/components/icon/icon.tsx
@@ -1,3 +1,5 @@
+import './icon.css'
+
 import React from 'react'
 
 type IconProps = {

--- a/src/components/input/baseInput/baseInput.tsx
+++ b/src/components/input/baseInput/baseInput.tsx
@@ -11,7 +11,7 @@ import { type ForwardedRef, forwardRef, useRef, useState } from 'react'
 import React from 'react'
 import { v4 as getUUID } from 'uuid'
 
-import Icon from '../../icon'
+import Icon from '../../icon/icon'
 import type { BaseInputProps, Message } from '../../types'
 
 function BaseInputElement(

--- a/src/components/map/openLayersMap.tsx
+++ b/src/components/map/openLayersMap.tsx
@@ -12,7 +12,7 @@ import View from 'ol/View.js'
 import React from 'react'
 import { useEffect, useRef, useState } from 'react'
 
-import Icon from '../icon'
+import Icon from '../icon/icon'
 import type { LocationFormat } from '../types'
 
 export default function OpenLayersMap(props: LocationFormat) {

--- a/src/components/media/controls/commonControls.tsx
+++ b/src/components/media/controls/commonControls.tsx
@@ -9,7 +9,7 @@ import Typography from '@mui/material/Typography'
 import React, { useState } from 'react'
 
 import { formatDurationTime } from '../../helper'
-import Icon from '../../icon'
+import Icon from '../../icon/icon'
 import { MediaIconButton } from './mediaIconButton'
 
 export interface MediaControls {

--- a/src/components/media/controls/mediaIconButton.tsx
+++ b/src/components/media/controls/mediaIconButton.tsx
@@ -2,7 +2,7 @@ import IconButton from '@mui/material/IconButton'
 import Tooltip from '@mui/material/Tooltip'
 import React from 'react'
 
-import Icon from '../../icon'
+import Icon from '../../icon/icon'
 
 interface MediaIconButtonProps {
   onClick: () => void
@@ -57,7 +57,10 @@ export function MediaIconButton(props: MediaIconButtonProps) {
         data-cy={`${dataCyPrefix}-button`}
         color="primary"
       >
-        <Icon name={controls[props.action].symbol} />
+        <Icon
+          name={controls[props.action].symbol}
+          className="rustic-icon-large"
+        />
       </IconButton>
     </Tooltip>
   )

--- a/src/components/menu/popoverMenu.cy.tsx
+++ b/src/components/menu/popoverMenu.cy.tsx
@@ -2,7 +2,7 @@
 import React from 'react'
 
 import { supportedViewports } from '../../../cypress/support/variables'
-import Icon from '../icon'
+import Icon from '../icon/icon'
 import PopoverMenu from './popoverMenu'
 
 describe('PopOverMenu', () => {

--- a/src/components/menu/popoverMenu.stories.tsx
+++ b/src/components/menu/popoverMenu.stories.tsx
@@ -2,7 +2,7 @@ import Typography from '@mui/material/Typography'
 import Box from '@mui/system/Box'
 import React from 'react'
 
-import Icon from '../icon'
+import Icon from '../icon/icon'
 import PopoverMenu from './popoverMenu'
 
 export default {

--- a/src/components/menu/popoverMenu.tsx
+++ b/src/components/menu/popoverMenu.tsx
@@ -13,7 +13,7 @@ import { Box } from '@mui/system'
 import type { ReactNode } from 'react'
 import React, { useRef, useState } from 'react'
 
-import Icon from '../icon'
+import Icon from '../icon/icon'
 
 export interface PopoverMenuItem {
   label: string

--- a/src/components/messageCanvas/actions/copy/copyText.tsx
+++ b/src/components/messageCanvas/actions/copy/copyText.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react'
 
-import Icon from '../../../icon'
+import Icon from '../../../icon/icon'
 import type { ThreadableMessage } from '../../../types'
 import Action from '../index'
 

--- a/src/components/messageCanvas/messageCanvas.cy.tsx
+++ b/src/components/messageCanvas/messageCanvas.cy.tsx
@@ -2,7 +2,7 @@
 import 'cypress-real-events'
 
 import { supportedViewports } from '../../../cypress/support/variables'
-import Icon from '../icon'
+import Icon from '../icon/icon'
 import type { ThreadableMessage } from '../types'
 import CopyText from './actions/copy/copyText'
 import MessageCanvas from './messageCanvas'

--- a/src/components/messageCanvas/messageCanvas.stories.tsx
+++ b/src/components/messageCanvas/messageCanvas.stories.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 
 import { ElementRenderer, type ThreadableMessage } from '..'
-import Icon from '../icon'
+import Icon from '../icon/icon'
 import Text from '../text/text'
 import CopyText from './actions/copy/copyText'
 import MessageCanvas from './messageCanvas'

--- a/src/components/messageSpace/messageSpace.cy.tsx
+++ b/src/components/messageSpace/messageSpace.cy.tsx
@@ -16,7 +16,7 @@ import {
   Text,
   YoutubeVideo,
 } from '..'
-import Icon from '../icon'
+import Icon from '../icon/icon'
 import MessageSpace from './messageSpace'
 
 describe('MessageSpace Component', () => {

--- a/src/components/messageSpace/messageSpace.stories.tsx
+++ b/src/components/messageSpace/messageSpace.stories.tsx
@@ -21,7 +21,7 @@ import {
   YoutubeVideo,
 } from '..'
 import CodeSnippet from '../codeSnippet/codeSnippet'
-import Icon from '../icon'
+import Icon from '../icon/icon'
 import CopyText from '../messageCanvas/actions/copy/copyText'
 import MessageSpace from './messageSpace'
 

--- a/src/components/messageSpace/messageSpace.tsx
+++ b/src/components/messageSpace/messageSpace.tsx
@@ -5,7 +5,7 @@ import Box from '@mui/system/Box'
 import React, { useEffect, useRef, useState } from 'react'
 
 import ElementRenderer from '../elementRenderer/elementRenderer'
-import Icon from '../icon'
+import Icon from '../icon/icon'
 import MessageCanvas, {
   type MessageContainerProps,
 } from '../messageCanvas/messageCanvas'

--- a/src/components/multipart/multipart.tsx
+++ b/src/components/multipart/multipart.tsx
@@ -7,7 +7,7 @@ import Box from '@mui/system/Box'
 import React from 'react'
 
 import FilePreview from '../filePreview/filePreview'
-import Icon from '../icon'
+import Icon from '../icon/icon'
 import Text from '../text/text'
 import type { MultipartData } from '../types'
 

--- a/src/components/participantsContainer/participantsContainer.tsx
+++ b/src/components/participantsContainer/participantsContainer.tsx
@@ -15,7 +15,7 @@ import React from 'react'
 import { useState } from 'react'
 
 import { capitalizeFirstLetter } from '../helper'
-import Icon from '../icon'
+import Icon from '../icon/icon'
 import { type Participant, ParticipantRole, ParticipantType } from '../types'
 
 export interface ParticipantsContainerProps {

--- a/src/components/tooltip/tooltip.stories.tsx
+++ b/src/components/tooltip/tooltip.stories.tsx
@@ -2,7 +2,7 @@ import IconButton from '@mui/material/IconButton'
 import Tooltip from '@mui/material/Tooltip'
 import React from 'react'
 
-import Icon from '../icon'
+import Icon from '../icon/icon'
 
 export default {
   title: 'Rustic UI/Tooltip/Tooltip',

--- a/src/components/visualization/chart/rechartsTimeSeries.tsx
+++ b/src/components/visualization/chart/rechartsTimeSeries.tsx
@@ -25,7 +25,7 @@ import {
 } from 'recharts'
 
 import { calculateTimeDiffInDays, formatTimestampLabel } from '../../helper'
-import Icon from '../../icon'
+import Icon from '../../icon/icon'
 
 export interface TimeSeriesData {
   timestamp: number


### PR DESCRIPTION
## Changes
- make media icon buttons larger
- add utility class for large icons

Addresses issue #95 .

## Screenshots
### Before
<img width="367" alt="Screenshot 2024-05-25 at 10 17 28 AM" src="https://github.com/rustic-ai/ui-components/assets/111031789/7e1abb82-8f86-4b96-be45-507de0ab1c62">
<img width="808" alt="Screenshot 2024-05-25 at 10 15 15 AM" src="https://github.com/rustic-ai/ui-components/assets/111031789/30f1aa76-d736-4245-a6cd-c714da344c76">
<img width="772" alt="Screenshot 2024-05-25 at 10 15 37 AM" src="https://github.com/rustic-ai/ui-components/assets/111031789/e4838f49-f1a8-429b-b4c8-8e03b7170235">


### After
<img width="367" alt="Screenshot 2024-05-25 at 10 17 42 AM" src="https://github.com/rustic-ai/ui-components/assets/111031789/14e78384-3afb-44e4-b4ff-d5d46ca9894c">
<img width="936" alt="Screenshot 2024-05-24 at 11 52 31 AM" src="https://github.com/rustic-ai/ui-components/assets/111031789/cf5b2a7e-2015-479d-bdf7-b7d5cdf2987a">
<img width="823" alt="Screenshot 2024-05-24 at 11 44 18 AM" src="https://github.com/rustic-ai/ui-components/assets/111031789/f3a67886-52e7-4ffe-ac30-26f3c46b2232">

