### PR TITLE
fix: update media progress bar colours

### DIFF
--- a/src/components/media/controls/commonControls.tsx
+++ b/src/components/media/controls/commonControls.tsx
@@ -1,5 +1,6 @@
 import './commonControls.css'
 
+import { useTheme } from '@mui/material'
 import Box from '@mui/material/Box'
 import Button from '@mui/material/Button'
 import LinearProgress from '@mui/material/LinearProgress'
@@ -32,6 +33,9 @@ interface MoveTenSecondsButtonProps extends MediaControls {
 const percentMultiple = 100
 
 export function ProgressSlider(props: MediaControls) {
+  const theme = useTheme()
+  const isDarkTheme = theme.palette.mode === 'dark'
+
   const formattedElapsedTime = formatDurationTime(
     props.mediaElement.currentTime
   )
@@ -63,6 +67,14 @@ export function ProgressSlider(props: MediaControls) {
         className="rustic-progress-buffered"
         variant="determinate"
         value={bufferedPercent}
+        sx={{
+          backgroundColor: theme.palette.action.focus,
+          '& .MuiLinearProgress-bar': {
+            backgroundColor: isDarkTheme
+              ? theme.palette.secondary.light
+              : theme.palette.action.selected,
+          },
+        }}
       />
     )
   }
@@ -82,6 +94,11 @@ export function ProgressSlider(props: MediaControls) {
         valueLabelDisplay="auto"
         valueLabelFormat={(value) => formatDurationTime(value)}
         color="secondary"
+        sx={{
+          '& .MuiSlider-rail': {
+            opacity: 0,
+          },
+        }}
       />
     </Box>
   )

--- a/src/components/media/controls/commonControls.tsx
+++ b/src/components/media/controls/commonControls.tsx
@@ -68,11 +68,11 @@ export function ProgressSlider(props: MediaControls) {
         variant="determinate"
         value={bufferedPercent}
         sx={{
-          backgroundColor: theme.palette.action.focus,
+          backgroundColor: 'action.focus',
           '& .MuiLinearProgress-bar': {
             backgroundColor: isDarkTheme
-              ? theme.palette.secondary.light
-              : theme.palette.action.selected,
+              ? 'secondary.light'
+              : 'action.selected',
           },
         }}
       />
@@ -96,7 +96,7 @@ export function ProgressSlider(props: MediaControls) {
         color="secondary"
         sx={{
           '& .MuiSlider-rail': {
-            opacity: 0,
+            color: 'action.focus',
           },
         }}
       />


### PR DESCRIPTION
## Changes
- update media progress bar colours

Addresses issue #96 .

## Screenshots
### Design
<img width="928" alt="Screenshot 2024-05-26 at 4 40 38 PM" src="https://github.com/rustic-ai/ui-components/assets/111031789/4e7cc43e-e2a0-445f-84fa-ea7b9ffd7913">

### Sound component
#### Before
<img width="273" alt="Screenshot 2024-05-26 at 10 21 07 AM" src="https://github.com/rustic-ai/ui-components/assets/111031789/aff08cea-2823-45e5-8fc0-e18573f9967c">
<img width="273" alt="Screenshot 2024-05-26 at 10 20 59 AM" src="https://github.com/rustic-ai/ui-components/assets/111031789/3c48b4ec-967e-49ff-a13a-c1510963fd0c">

#### After
<img width="276" alt="Screenshot 2024-05-26 at 10 13 24 AM" src="https://github.com/rustic-ai/ui-components/assets/111031789/497e49f3-3d69-46e8-ba03-e3445be83f88">
<img width="276" alt="Screenshot 2024-05-26 at 10 13 14 AM" src="https://github.com/rustic-ai/ui-components/assets/111031789/54754613-0df4-4954-bf29-5423ebd3d4a8">

### Video component
#### Before
<img width="813" alt="Screenshot 2024-05-26 at 10 19 59 AM" src="https://github.com/rustic-ai/ui-components/assets/111031789/becee48e-74a0-4525-b88d-115abf65e0c2">
<img width="813" alt="Screenshot 2024-05-26 at 10 20 14 AM" src="https://github.com/rustic-ai/ui-components/assets/111031789/c6addc9b-f95b-41d2-895d-db558a03a520">

#### After
<img width="813" alt="Screenshot 2024-05-26 at 10 14 17 AM" src="https://github.com/rustic-ai/ui-components/assets/111031789/8b623caf-c7a6-474d-9959-b22d7651f58a">
<img width="813" alt="Screenshot 2024-05-26 at 10 14 04 AM" src="https://github.com/rustic-ai/ui-components/assets/111031789/bdf81f5b-6baf-421f-b6b3-63d129bc3adf">
