### PR TITLE
fix!: update messageCanvas styling

### DIFF
--- a/src/components/messageCanvas/messageCanvas.css
+++ b/src/components/messageCanvas/messageCanvas.css
@@ -7,12 +7,6 @@
   padding: 16px;
 }
 
-.rustic-message-canvas .rustic-sender-info {
-  flex-direction: row;
-  align-items: center;
-  gap: 8px;
-}
-
 .rustic-message-canvas .rustic-message-actions-container {
   opacity: 0;
   position: absolute;
@@ -23,7 +17,7 @@
 }
 
 .rustic-message-canvas .rustic-timestamp {
-  margin-left: 8px;
+  margin-left: 16px;
   align-self: flex-end;
 }
 

--- a/src/components/messageCanvas/messageCanvas.css
+++ b/src/components/messageCanvas/messageCanvas.css
@@ -18,7 +18,6 @@
 
 .rustic-message-canvas .rustic-timestamp {
   margin-left: 16px;
-  align-self: flex-end;
 }
 
 .rustic-message-canvas:hover .rustic-message-actions-container {

--- a/src/components/messageCanvas/messageCanvas.css
+++ b/src/components/messageCanvas/messageCanvas.css
@@ -1,29 +1,44 @@
 .rustic-message-canvas {
-  display: flex;
-  flex-direction: column;
   gap: 4px;
+  position: relative;
 }
 
-.rustic-message-canvas .rustic-message-actions-container {
+.rustic-message-canvas .rustic-message-container {
   padding: 16px;
 }
 
 .rustic-message-canvas .rustic-sender-info {
-  display: flex;
+  flex-direction: row;
   align-items: center;
   gap: 8px;
 }
 
-.rustic-message-canvas .rustic-message-footer {
+.rustic-message-canvas .rustic-message-actions-container {
   opacity: 0;
+  position: absolute;
+  top: 4px;
+  right: 16px;
   display: flex;
   align-items: center;
 }
 
-.rustic-message-canvas:hover .rustic-message-footer {
+.rustic-message-canvas .rustic-timestamp {
+  margin-left: 8px;
+}
+
+.rustic-message-canvas:hover .rustic-message-actions-container {
   opacity: 1;
 }
 
-.rustic-message-canvas .rustic-timestamp {
-  margin-left: auto;
+@media (max-width: 900px) {
+  .rustic-message-canvas .rustic-message-actions-container {
+    bottom: -20px;
+    top: unset;
+  }
+
+  .rustic-message-canvas .rustic-timestamp {
+    display: flex;
+    flex: 1;
+    justify-content: flex-end;
+  }
 }

--- a/src/components/messageCanvas/messageCanvas.css
+++ b/src/components/messageCanvas/messageCanvas.css
@@ -24,6 +24,7 @@
 
 .rustic-message-canvas .rustic-timestamp {
   margin-left: 8px;
+  align-self: flex-end;
 }
 
 .rustic-message-canvas:hover .rustic-message-actions-container {

--- a/src/components/messageCanvas/messageCanvas.cy.tsx
+++ b/src/components/messageCanvas/messageCanvas.cy.tsx
@@ -18,20 +18,6 @@ describe('MessageCanvas', () => {
     data: { text: 'Hello World' },
   }
 
-  const testMessageUpdate = {
-    ...testMessage,
-    lastThreadMessage: {
-      id: '3',
-      timestamp: '2020-01-02T00:00:00.000Z',
-      sender: 'senderId',
-      conversationId: 'lkd9vc',
-      topicId: 'default',
-      threadId: '2',
-      format: 'text',
-      data: { text: '!' },
-    },
-  }
-
   const messageCanvas = '[data-cy=message-canvas]'
   supportedViewports.forEach((viewport) => {
     it(`renders the component on ${viewport} screen`, () => {
@@ -47,6 +33,7 @@ describe('MessageCanvas', () => {
 
       cy.contains('Hello World').should('be.visible')
       cy.contains('senderId').should('be.visible')
+      cy.contains('Jan 1, 2020').should('be.visible')
       cy.get('[data-cy="account-circle-icon"]').should('be.visible')
     })
 
@@ -78,62 +65,6 @@ describe('MessageCanvas', () => {
           expect(text).to.eq('Hello World')
         })
       })
-    })
-  })
-
-  context('Desktop', () => {
-    beforeEach(() => {
-      cy.viewport('macbook-13')
-    })
-
-    it('shows timestamp on hover', () => {
-      cy.mount(
-        <MessageCanvas message={testMessage}>
-          <p>Hello World</p>
-        </MessageCanvas>
-      )
-      cy.contains('Jan 1, 2020').should('not.be.visible')
-      cy.get(messageCanvas).realHover()
-      cy.contains('Jan 1, 2020').should('be.visible')
-    })
-
-    it('shows that it was last updated if an update is provided', () => {
-      cy.mount(
-        <MessageCanvas message={testMessageUpdate}>
-          <p>Hello World</p>
-        </MessageCanvas>
-      )
-
-      cy.get(messageCanvas).realHover()
-      cy.contains('last updated').should('be.visible')
-    })
-  })
-
-  context('Mobile', () => {
-    beforeEach(() => {
-      cy.viewport('iphone-6')
-    })
-
-    it('shows timestamp on touch', () => {
-      cy.mount(
-        <MessageCanvas message={testMessage}>
-          <p>Hello World</p>
-        </MessageCanvas>
-      )
-      cy.contains('Jan 1, 2020').should('not.be.visible')
-      cy.get(messageCanvas).realTouch()
-      cy.contains('Jan 1, 2020').should('be.visible')
-    })
-
-    it('shows that it was last updated if an update is provided', () => {
-      cy.mount(
-        <MessageCanvas message={testMessageUpdate}>
-          <p>Hello World</p>
-        </MessageCanvas>
-      )
-
-      cy.get(messageCanvas).realTouch()
-      cy.contains('last updated').should('be.visible')
     })
   })
 })

--- a/src/components/messageCanvas/messageCanvas.tsx
+++ b/src/components/messageCanvas/messageCanvas.tsx
@@ -1,8 +1,9 @@
 import './messageCanvas.css'
 
+import { useTheme } from '@mui/material'
 import Card from '@mui/material/Card'
+import Stack from '@mui/material/Stack'
 import Typography from '@mui/material/Typography'
-import Box from '@mui/system/Box'
 import React, { forwardRef, type ReactNode } from 'react'
 
 import Timestamp from '../timestamp/timestamp'
@@ -36,42 +37,36 @@ function MessageCanvasElement(
   props: MessageCanvasProps,
   ref: React.Ref<HTMLDivElement>
 ) {
+  const theme = useTheme()
+
   return (
-    <Box
+    <Stack
       id={props.message.id}
       className="rustic-message-canvas"
       data-cy="message-canvas"
       ref={ref}
     >
-      <Box className="rustic-sender-info">
+      <Stack className="rustic-sender-info">
         {props.getProfileComponent && props.getProfileComponent(props.message)}
-        <Typography variant="body2" color="text.secondary" data-cy="sender">
-          {props.message.sender}:
+        <Typography variant="body1" color="text.secondary" data-cy="sender">
+          {props.message.sender}
         </Typography>
-      </Box>
-      <Card variant="outlined" className="rustic-message-actions-container">
+        <Timestamp timestamp={props.message.timestamp} />
+      </Stack>
+      {props.getActionsComponent &&
+        props.getActionsComponent(props.message) && (
+          <Card
+            variant="outlined"
+            className="rustic-message-actions-container"
+            sx={{ boxShadow: theme.shadows[1] }}
+          >
+            {props.getActionsComponent(props.message)}
+          </Card>
+        )}
+      <Card variant="outlined" className="rustic-message-container">
         {props.children}
       </Card>
-      <Box className="rustic-message-footer">
-        {props.getActionsComponent &&
-          props.getActionsComponent(props.message) && (
-            <Card variant="outlined">
-              {props.getActionsComponent(props.message)}
-            </Card>
-          )}
-        <Box className="rustic-timestamp">
-          {props.message.lastThreadMessage && (
-            <Typography variant="caption">last updated: </Typography>
-          )}
-          <Timestamp
-            timestamp={
-              props.message.lastThreadMessage?.timestamp ||
-              props.message.timestamp
-            }
-          />
-        </Box>
-      </Box>
-    </Box>
+    </Stack>
   )
 }
 

--- a/src/components/messageCanvas/messageCanvas.tsx
+++ b/src/components/messageCanvas/messageCanvas.tsx
@@ -46,7 +46,7 @@ function MessageCanvasElement(
       data-cy="message-canvas"
       ref={ref}
     >
-      <Stack className="rustic-sender-info">
+      <Stack direction="row" alignItems="center" spacing={1}>
         {props.getProfileComponent && props.getProfileComponent(props.message)}
         <Typography variant="body1" color="text.secondary" data-cy="sender">
           {props.message.sender}

--- a/src/components/timestamp/timestamp.tsx
+++ b/src/components/timestamp/timestamp.tsx
@@ -10,7 +10,11 @@ export interface TimestampProps {
 
 const Timestamp = (props: TimestampProps) => {
   return (
-    <Typography variant="caption" color="textSecondary">
+    <Typography
+      variant="caption"
+      color="textSecondary"
+      className="rustic-timestamp"
+    >
       {formatMessageTimestamp(props.timestamp)}
     </Typography>
   )

--- a/src/components/timestamp/timestamp.tsx
+++ b/src/components/timestamp/timestamp.tsx
@@ -12,7 +12,7 @@ const Timestamp = (props: TimestampProps) => {
   return (
     <Typography
       variant="caption"
-      color="textSecondary"
+      color="text.secondary"
       className="rustic-timestamp"
     >
       {formatMessageTimestamp(props.timestamp)}


### PR DESCRIPTION
BREAKING CHANGE: Changes in classnames.

## Changes
- `rustic-message-actions-container` is now `rustic-message-container`
- `rustic-message-actions-container` is now applied to the message actions, as before it was added to the message content
- remove 'last updated:' next to timestamp
- update styling to match updated design

The message actions on mobile in the design are accessed by clicking/holding the message and having a drawer menu appear. We don't have logic implemented for this yet, so I've moved the message actions to the bottom on mobile.

## Screenshots

### Design
#### Desktop
<img width="732" alt="Screenshot 2024-05-27 at 10 23 49 AM" src="https://github.com/rustic-ai/ui-components/assets/111031789/a6508628-af4c-4bbd-aae3-0798049c3960">

#### Mobile
<img width="366" alt="Screenshot 2024-05-27 at 10 24 16 AM" src="https://github.com/rustic-ai/ui-components/assets/111031789/bbbd50e6-29ec-46fe-b039-bbd45f7b5976">

### Before
#### No hover
![Screenshot 2024-05-27 at 3 35 16 PM](https://github.com/rustic-ai/ui-components/assets/111031789/e3f555f6-fc58-4193-b9e6-1ddfd14f6502)
#### On hover
![Screenshot 2024-05-27 at 3 35 20 PM](https://github.com/rustic-ai/ui-components/assets/111031789/d0580faa-a54c-4d56-8dd2-343949ea2328)

#### Message space no hover
![Screenshot 2024-05-27 at 3 36 53 PM](https://github.com/rustic-ai/ui-components/assets/111031789/5f0dfe89-6f53-4f66-8d2d-766ef81986cd)

#### Message space on hover
![Screenshot 2024-05-27 at 3 36 48 PM](https://github.com/rustic-ai/ui-components/assets/111031789/197ab2c7-faa2-45d5-b9d9-c6be7753e171)


### After
#### No hover
![Screenshot 2024-05-27 at 3 42 17 PM](https://github.com/rustic-ai/ui-components/assets/111031789/7fdf965b-8c1b-43c8-8f6c-7434432df724)

#### On hover
![Screenshot 2024-05-27 at 3 42 14 PM](https://github.com/rustic-ai/ui-components/assets/111031789/3d976866-7f21-4070-991f-8a8dfb1f6019)

#### On hover mobile
![Screenshot 2024-05-27 at 3 32 09 PM](https://github.com/rustic-ai/ui-components/assets/111031789/78507de8-051a-46c8-aa0c-5c986f6c99fb)

#### Message space no hover
![Screenshot 2024-05-27 at 3 41 59 PM](https://github.com/rustic-ai/ui-components/assets/111031789/e96d2f6a-bc20-419f-8589-d91032f162aa)

#### Message space on hover
![Screenshot 2024-05-27 at 3 41 55 PM](https://github.com/rustic-ai/ui-components/assets/111031789/64650245-9191-4264-9120-fd8b2f81d078)
