### PR TITLE
feat(popoverMenu): support href

### DIFF
--- a/src/components/menu/popoverMenu.cy.tsx
+++ b/src/components/menu/popoverMenu.cy.tsx
@@ -117,7 +117,7 @@ describe('PopOverMenu', () => {
             {
               label: 'Download SVG',
               href: 'https://example.com/file.svg',
-              download: 'file.svg',
+              downloadFileName: 'file.svg',
             },
           ]}
           ariaLabel={ariaLabel}

--- a/src/components/menu/popoverMenu.cy.tsx
+++ b/src/components/menu/popoverMenu.cy.tsx
@@ -109,6 +109,28 @@ describe('PopOverMenu', () => {
       cy.get('@consoleLogSpy').should('be.calledWith', 'click')
     })
 
+    it(`should render menu item with correct href and download attributes on ${viewport} screen`, () => {
+      cy.viewport(viewport)
+      cy.mount(
+        <PopoverMenu
+          menuItems={[
+            {
+              label: 'Download SVG',
+              href: 'https://example.com/file.svg',
+              downloadFileName: 'file.svg',
+            },
+          ]}
+          ariaLabel={ariaLabel}
+        />
+      )
+
+      cy.get(openMenu).click()
+
+      cy.get('a')
+        .should('have.attr', 'href', 'https://example.com/file.svg')
+        .and('have.attr', 'download', 'file.svg')
+    })
+
     it(`renders the correct button if the buttonText prop is provided on ${viewport} screen`, () => {
       const button = '[data-cy=menu-button]'
       const iconButton = '[data-cy=menu-icon-button]'

--- a/src/components/menu/popoverMenu.cy.tsx
+++ b/src/components/menu/popoverMenu.cy.tsx
@@ -117,7 +117,7 @@ describe('PopOverMenu', () => {
             {
               label: 'Download SVG',
               href: 'https://example.com/file.svg',
-              downloadFileName: 'file.svg',
+              download: 'file.svg',
             },
           ]}
           ariaLabel={ariaLabel}

--- a/src/components/menu/popoverMenu.stories.tsx
+++ b/src/components/menu/popoverMenu.stories.tsx
@@ -35,7 +35,8 @@ meta.argTypes = {
           '  startDecorator: An optional React node that will be rendered at the beginning of the menu item. This can be used for icons or other decorative elements.\n' +
           '  endDecorator: An optional React node that will be rendered at the end of the menu item. This is typically used for icons or other decorative elements.\n' +
           '  href: An optional URL that, if provided, makes the menu item behave like a link. When the menu item is clicked, the browser will navigate to this URL.\n' +
-          '  download: An optional boolean or string attribute that prompts the browser to download the linked URL. If a string is provided, it will be used as the filename for the downloaded file.',
+          '  isFiledownload: An optional boolean that, when true, prompts the browser to download the linked URL as a file.' +
+          '  downloadFileName: An optional string that specifies a custom file name for the downloaded file, overriding the original name.',
       },
     },
   },
@@ -224,7 +225,7 @@ export const WithDownloadLink = {
       {
         label: 'Download Logo',
         href: 'images/rustic-ui-logo.svg',
-        download: true,
+        isFiledownload: true,
       },
     ],
     ariaLabel: 'open default menu',

--- a/src/components/menu/popoverMenu.stories.tsx
+++ b/src/components/menu/popoverMenu.stories.tsx
@@ -1,11 +1,12 @@
 import Typography from '@mui/material/Typography'
 import Box from '@mui/system/Box'
+import type { Meta } from '@storybook/react'
 import React from 'react'
 
 import Icon from '../icon/icon'
 import PopoverMenu from './popoverMenu'
 
-export default {
+const meta: Meta<React.ComponentProps<typeof PopoverMenu>> = {
   title: 'Rustic UI/Menu/Popover Menu',
   component: PopoverMenu,
   tags: ['autodocs'],
@@ -18,10 +19,24 @@ export default {
       },
     },
   },
-  argTypes: {
-    menuItems: {
-      description:
-        'An array of menu items to be displayed in the menu. \n<pre>```interface PopoverMenuItem {\n  label: string\n  onClick: (event?: React.MouseEvent<HTMLElement>) => void\n  startDecorator?: ReactNode\n  endDecorator: ReactNode\n}```</pre>',
+}
+export default meta
+
+meta.argTypes = {
+  ...meta.argTypes,
+  menuItems: {
+    table: {
+      type: {
+        summary: 'An array of PopoverMenuItem.\n',
+        detail:
+          'Each PopoverMenuItem has the following fields:\n' +
+          '  label: Text label displayed for the menu item..\n' +
+          '  onClick: An optional function that gets called when the menu item is clicked. It receives an optional MouseEvent object as an argument.\n' +
+          '  startDecorator: An optional React node that will be rendered at the beginning of the menu item. This can be used for icons or other decorative elements.\n' +
+          '  endDecorator: An optional React node that will be rendered at the end of the menu item. This is typically used for icons or other decorative elements.\n' +
+          '  href: An optional URL that, if provided, makes the menu item behave like a link. When the menu item is clicked, the browser will navigate to this URL.\n' +
+          '  downloadFileName: An optional string specifying the filename for downloading content. This works in conjunction with the href property to allow users to download a file when the menu item is clicked.',
+      },
     },
   },
 }
@@ -188,5 +203,30 @@ export const WithCustomButtonIconAndText = {
     ariaLabel: 'open menu showing custom button icon and text',
     icon: listIcon,
     buttonText: 'Menu',
+  },
+}
+
+export const WithLink = {
+  args: {
+    menuItems: [
+      {
+        label: 'Go To Rustic AI',
+        href: 'https://www.rustic.ai',
+      },
+    ],
+    ariaLabel: 'open default menu',
+  },
+}
+
+export const WithDownloadLink = {
+  args: {
+    menuItems: [
+      {
+        label: 'Download Logo',
+        href: 'images/rustic-ui-logo.svg',
+        downloadFileName: 'rustic-logo',
+      },
+    ],
+    ariaLabel: 'open default menu',
   },
 }

--- a/src/components/menu/popoverMenu.stories.tsx
+++ b/src/components/menu/popoverMenu.stories.tsx
@@ -35,7 +35,7 @@ meta.argTypes = {
           '  startDecorator: An optional React node that will be rendered at the beginning of the menu item. This can be used for icons or other decorative elements.\n' +
           '  endDecorator: An optional React node that will be rendered at the end of the menu item. This is typically used for icons or other decorative elements.\n' +
           '  href: An optional URL that, if provided, makes the menu item behave like a link. When the menu item is clicked, the browser will navigate to this URL.\n' +
-          '  downloadFileName: An optional string specifying the filename for downloading content. This works in conjunction with the href property to allow users to download a file when the menu item is clicked.',
+          '  download: An optional boolean or string attribute that prompts the browser to download the linked URL. If a string is provided, it will be used as the filename for the downloaded file.',
       },
     },
   },
@@ -224,7 +224,7 @@ export const WithDownloadLink = {
       {
         label: 'Download Logo',
         href: 'images/rustic-ui-logo.svg',
-        downloadFileName: 'rustic-logo',
+        download: true,
       },
     ],
     ariaLabel: 'open default menu',

--- a/src/components/menu/popoverMenu.tsx
+++ b/src/components/menu/popoverMenu.tsx
@@ -19,7 +19,7 @@ export interface PopoverMenuItem {
   label: string
   onClick?: (event?: React.MouseEvent<HTMLElement>) => void
   href?: string
-  downloadFileName?: string
+  download?: string | boolean
   startDecorator?: ReactNode
   endDecorator?: ReactNode
 }
@@ -98,7 +98,7 @@ export default function PopoverMenu(props: PopoverMenuProps) {
           key={menuItem.label}
           onClick={() => setIsMenuOpen(false)}
           href={menuItem.href}
-          download={menuItem.downloadFileName}
+          download={menuItem.download}
         >
           {renderMenuItemContent(menuItem)}
         </MenuItem>

--- a/src/components/menu/popoverMenu.tsx
+++ b/src/components/menu/popoverMenu.tsx
@@ -19,7 +19,8 @@ export interface PopoverMenuItem {
   label: string
   onClick?: (event?: React.MouseEvent<HTMLElement>) => void
   href?: string
-  download?: string | boolean
+  isFiledownload?: boolean
+  downloadFileName?: string
   startDecorator?: ReactNode
   endDecorator?: ReactNode
 }
@@ -87,8 +88,8 @@ export default function PopoverMenu(props: PopoverMenuProps) {
     function handleOnClick(event: React.MouseEvent<HTMLElement>) {
       if (menuItem.onClick) {
         menuItem.onClick(event)
-        setIsMenuOpen(false)
       }
+      setIsMenuOpen(false)
     }
 
     if (menuItem.href) {
@@ -98,7 +99,7 @@ export default function PopoverMenu(props: PopoverMenuProps) {
           key={menuItem.label}
           onClick={() => setIsMenuOpen(false)}
           href={menuItem.href}
-          download={menuItem.download}
+          download={menuItem.downloadFileName || menuItem.isFiledownload}
         >
           {renderMenuItemContent(menuItem)}
         </MenuItem>

--- a/src/components/menu/popoverMenu.tsx
+++ b/src/components/menu/popoverMenu.tsx
@@ -17,7 +17,9 @@ import Icon from '../icon/icon'
 
 export interface PopoverMenuItem {
   label: string
-  onClick: (event?: React.MouseEvent<HTMLElement>) => void
+  onClick?: (event?: React.MouseEvent<HTMLElement>) => void
+  href?: string
+  downloadFileName?: string
   startDecorator?: ReactNode
   endDecorator?: ReactNode
 }
@@ -55,14 +57,9 @@ export default function PopoverMenu(props: PopoverMenuProps) {
     }
   }
 
-  const menuItems = props.menuItems.map((menuItem) => {
-    function handleOnClick(event: React.MouseEvent<HTMLElement>) {
-      menuItem.onClick(event)
-      setIsMenuOpen(false)
-    }
-
+  function renderMenuItemContent(menuItem: PopoverMenuItem) {
     return (
-      <MenuItem key={menuItem.label} onClick={handleOnClick}>
+      <>
         {menuItem.startDecorator && (
           <Box
             sx={{ color: 'primary.main' }}
@@ -82,8 +79,41 @@ export default function PopoverMenu(props: PopoverMenuProps) {
             {menuItem.endDecorator}
           </Box>
         )}
-      </MenuItem>
+      </>
     )
+  }
+
+  const menuItems = props.menuItems.map((menuItem) => {
+    function handleOnClick(event: React.MouseEvent<HTMLElement>) {
+      if (menuItem.onClick) {
+        menuItem.onClick(event)
+        setIsMenuOpen(false)
+      }
+    }
+
+    if (menuItem.href) {
+      return (
+        <MenuItem
+          component="a"
+          key={menuItem.label}
+          onClick={() => setIsMenuOpen(false)}
+          href={menuItem.href}
+          download={menuItem.downloadFileName}
+        >
+          {renderMenuItemContent(menuItem)}
+        </MenuItem>
+      )
+    } else {
+      return (
+        <MenuItem
+          key={menuItem.label}
+          onClick={handleOnClick}
+          disabled={!menuItem.onClick}
+        >
+          {renderMenuItemContent(menuItem)}
+        </MenuItem>
+      )
+    }
   })
 
   function handleOpenMenu(event: React.MouseEvent<HTMLElement>) {


### PR DESCRIPTION
## Change:
- Add `href` and `isFileDownload` and `downloadFileName` to `PopoverMenuItem`
- Update stories and tests

Question: Should I also add `target` to specify where to open the link?

## Video
### Link
![May-27-2024 20-19-17](https://github.com/rustic-ai/ui-components/assets/103023797/98b7087a-bcaa-44d4-8c44-7822e7b38d83)
### Download
![May-27-2024 20-20-49](https://github.com/rustic-ai/ui-components/assets/103023797/29302264-3954-4cff-aed4-06d90e62b0fa)
