### PR TITLE
fix(messageSpace): update color of scroll down button

### DIFF
--- a/src/components/messageSpace/messageSpace.tsx
+++ b/src/components/messageSpace/messageSpace.tsx
@@ -181,6 +181,7 @@ export default function MessageSpace(props: MessageSpaceProps) {
         <Button
           data-cy="scroll-down-button"
           variant="contained"
+          color="secondary"
           className="rustic-scroll-down-button"
           onClick={handleScrollDown}
           endIcon={<Icon name="arrow_downward" className="rustic-end-icon" />}


### PR DESCRIPTION
## Changes
- update color of scroll down button

Addresses issue #156.

Will have to look into the how `rusticDarkTheme` aligns with MUI default styles for buttons with both `variant='contained'` and `color='primary'` .

## Screenshots
### Before
<img width="799" alt="Screenshot 2024-05-28 at 3 05 38 PM" src="https://github.com/rustic-ai/ui-components/assets/111031789/dbc1b4bd-51a7-473a-ac06-b336bacbf34b">
<img width="799" alt="Screenshot 2024-05-28 at 3 05 33 PM" src="https://github.com/rustic-ai/ui-components/assets/111031789/6d956884-4aea-4b76-b158-a2c066053ad8">

### After
<img width="799" alt="Screenshot 2024-05-28 at 3 04 35 PM" src="https://github.com/rustic-ai/ui-components/assets/111031789/6c30f8ec-7abd-42cd-a25b-b89731214e88">
<img width="799" alt="Screenshot 2024-05-28 at 3 04 30 PM" src="https://github.com/rustic-ai/ui-components/assets/111031789/ea59f2d7-0609-4f15-a64e-8ab39235de5b">
