### PR TITLE
feat(table): add pagination

### DIFF
--- a/src/components/table/table.css
+++ b/src/components/table/table.css
@@ -5,3 +5,28 @@
 .rustic-table .rustic-table-container {
   max-height: 40vh;
 }
+
+.rustic-table .rustic-table-pagination .rustic-toolbar {
+  padding: 0;
+}
+
+.rustic-table .rustic-table-pagination .rustic-input {
+  margin-left: 0;
+}
+
+@media (max-width: 900px) {
+  .rustic-table .rustic-table-pagination .rustic-spacer {
+    position: absolute;
+  }
+
+  .rustic-table .rustic-table-pagination .rustic-displayed-rows {
+    flex: 1;
+    display: flex;
+    justify-content: flex-end;
+    white-space: nowrap;
+  }
+
+  .rustic-table .rustic-table-pagination .rustic-actions {
+    margin-left: 8px;
+  }
+}

--- a/src/components/table/table.css
+++ b/src/components/table/table.css
@@ -5,7 +5,3 @@
 .rustic-table .rustic-table-container {
   max-height: 40vh;
 }
-
-.rustic-table .rustic-table-pagination {
-  min-height: 52px;
-}

--- a/src/components/table/table.css
+++ b/src/components/table/table.css
@@ -5,3 +5,11 @@
 .rustic-table .rustic-table-title {
   text-align: center;
 }
+
+.rustic-table .rustic-table-container {
+  max-height: 40vh;
+}
+
+.rustic-table .rustic-table-pagination {
+  min-height: 52px;
+}

--- a/src/components/table/table.css
+++ b/src/components/table/table.css
@@ -6,27 +6,27 @@
   max-height: 40vh;
 }
 
-.rustic-table .rustic-table-pagination .rustic-toolbar {
+.rustic-table .rustic-table-pagination .rustic-table-toolbar {
   padding: 0;
 }
 
-.rustic-table .rustic-table-pagination .rustic-input {
+.rustic-table .rustic-table-pagination .rustic-table-input {
   margin-left: 0;
 }
 
 @media (max-width: 900px) {
-  .rustic-table .rustic-table-pagination .rustic-spacer {
+  .rustic-table .rustic-table-pagination .rustic-table-spacer {
     position: absolute;
   }
 
-  .rustic-table .rustic-table-pagination .rustic-displayed-rows {
+  .rustic-table .rustic-table-pagination .rustic-table-displayed-rows {
     flex: 1;
     display: flex;
     justify-content: flex-end;
     white-space: nowrap;
   }
 
-  .rustic-table .rustic-table-pagination .rustic-actions {
+  .rustic-table .rustic-table-pagination .rustic-table-actions {
     margin-left: 8px;
   }
 }

--- a/src/components/table/table.css
+++ b/src/components/table/table.css
@@ -2,10 +2,6 @@
   max-width: calc(100vw - 100px);
 }
 
-.rustic-table .rustic-table-title {
-  text-align: center;
-}
-
 .rustic-table .rustic-table-container {
   max-height: 40vh;
 }

--- a/src/components/table/table.cy.tsx
+++ b/src/components/table/table.cy.tsx
@@ -107,7 +107,6 @@ describe('Table', () => {
       const rowsPerPage = 2
 
       cy.viewport(viewport)
-      // eslint-disable-next-line no-magic-numbers
       cy.mount(
         <Table
           rowsPerPageOptions={[rowsPerPage]}

--- a/src/components/table/table.cy.tsx
+++ b/src/components/table/table.cy.tsx
@@ -6,6 +6,7 @@ describe('Table', () => {
     { col1: 'abc', col2: 123 },
     { col1: 'def', col2: 456 },
   ]
+
   const firstRowIndex = 0
 
   supportedViewports.forEach((viewport) => {
@@ -99,6 +100,25 @@ describe('Table', () => {
             expect(cell.text().trim()).to.equal(value.toString())
           })
       })
+    })
+
+    it(`has pagination if rowsPerPageOptions prop is provided on ${viewport} screen`, () => {
+      const tablePagination = '[data-cy="table-pagination"]'
+      const rowsPerPage = 2
+
+      cy.viewport(viewport)
+      // eslint-disable-next-line no-magic-numbers
+      cy.mount(
+        <Table
+          rowsPerPageOptions={[rowsPerPage]}
+          data={[...testData, { col1: 'ghi', col2: 789 }]}
+        />
+      )
+      cy.get('tbody tr').should('have.length', rowsPerPage)
+      cy.get(tablePagination).should('contain', '1–2 of 3')
+      cy.get(`${tablePagination} button`).last().click()
+      cy.get('tbody tr').should('have.length', 1)
+      cy.get(tablePagination).should('contain', '3–3 of 3')
     })
   })
 })

--- a/src/components/table/table.cy.tsx
+++ b/src/components/table/table.cy.tsx
@@ -7,6 +7,86 @@ describe('Table', () => {
     { col1: 'def', col2: 456 },
   ]
 
+  const manyDataRows = [
+    {
+      food: 'almond milk',
+      calories: 30,
+      carbs: 1.0,
+      protein: 1.0,
+      fat: 2.5,
+    },
+    {
+      food: 'soy milk',
+      calories: 80,
+      carbs: 4.0,
+      protein: 7.0,
+      fat: 4.0,
+    },
+    {
+      food: 'rice milk',
+      calories: 120,
+      carbs: 22.0,
+      protein: 1.0,
+      fat: 2.5,
+    },
+    {
+      food: 'coconut milk',
+      calories: 45,
+      carbs: 2.0,
+      protein: 0.5,
+      fat: 4.5,
+    },
+    {
+      food: 'oat milk',
+      calories: 120,
+      carbs: 16.0,
+      protein: 3.0,
+      fat: 5.0,
+    },
+    {
+      food: 'hemp milk',
+      calories: 70,
+      carbs: 1.0,
+      protein: 3.0,
+      fat: 6.0,
+    },
+    {
+      food: 'cashew milk',
+      calories: 25,
+      carbs: 1.0,
+      protein: 1.0,
+      fat: 2.0,
+    },
+    {
+      food: 'pea milk',
+      calories: 70,
+      carbs: 0.0,
+      protein: 8.0,
+      fat: 4.5,
+    },
+    {
+      food: 'goat milk',
+      calories: 168,
+      carbs: 11.0,
+      protein: 9.0,
+      fat: 10.0,
+    },
+    {
+      food: 'camel milk',
+      calories: 107,
+      carbs: 5.8,
+      protein: 5.2,
+      fat: 4.5,
+    },
+    {
+      food: 'buffalo milk',
+      calories: 237,
+      carbs: 12.0,
+      protein: 9.0,
+      fat: 16.0,
+    },
+  ]
+
   const firstRowIndex = 0
 
   supportedViewports.forEach((viewport) => {
@@ -102,22 +182,23 @@ describe('Table', () => {
       })
     })
 
-    it(`has pagination if rowsPerPageOptions prop is provided on ${viewport} screen`, () => {
+    it(`has pagination if there are more than 10 data rows on ${viewport} screen`, () => {
       const tablePagination = '[data-cy="table-pagination"]'
-      const rowsPerPage = 2
+      const initialRowsPerPage = 10
 
       cy.viewport(viewport)
-      cy.mount(
-        <Table
-          rowsPerPageOptions={[rowsPerPage]}
-          data={[...testData, { col1: 'ghi', col2: 789 }]}
-        />
+      cy.mount(<Table data={manyDataRows} />)
+      cy.get('tbody tr').should('have.length', initialRowsPerPage)
+      cy.get(tablePagination).should(
+        'contain',
+        `1–${initialRowsPerPage} of ${manyDataRows.length}`
       )
-      cy.get('tbody tr').should('have.length', rowsPerPage)
-      cy.get(tablePagination).should('contain', '1–2 of 3')
       cy.get(`${tablePagination} button`).last().click()
       cy.get('tbody tr').should('have.length', 1)
-      cy.get(tablePagination).should('contain', '3–3 of 3')
+      cy.get(tablePagination).should(
+        'contain',
+        `11–11 of ${manyDataRows.length}`
+      )
     })
   })
 })

--- a/src/components/table/table.stories.tsx
+++ b/src/components/table/table.stories.tsx
@@ -11,7 +11,7 @@ const meta: Meta<React.ComponentProps<typeof Table>> = {
     docs: {
       description: {
         component:
-          'The `Table` component provides a simple and customizable table display for presenting structured data. It supports rendering data rows with associated headers and allows for easy customization of table title, description, and column headers.',
+          'The `Table` component provides a simple and customizable table display for presenting structured data. It supports rendering data rows with associated headers and allows for easy customization of table title, description, and column headers. Pagination is enabled when the number of rows exceeds 10.',
       },
     },
   },
@@ -204,7 +204,7 @@ export const CustomizeHeaders = {
   },
 }
 
-export const WithPagination = {
+export const MoreThanTenRows = {
   args: {
     ...textData,
     data: manyDataRows,

--- a/src/components/table/table.stories.tsx
+++ b/src/components/table/table.stories.tsx
@@ -39,6 +39,12 @@ meta.argTypes = {
 
 export default meta
 
+const textData = {
+  title: 'Nutrient Data Comparison Across Various Types of Milk',
+  description:
+    'This table illustrates the variations in calories and nutrients for different types of milk, with measurements based on a serving size of 250 ml. Caloric values are expressed in kCal, and nutrient quantities are measured in grams. The data is sourced from the Canadian Nutrient File.',
+}
+
 const sampleData = [
   {
     food: 'chocolate milk',
@@ -77,6 +83,87 @@ const sampleData = [
   },
 ]
 
+const manyDataRows = [
+  ...sampleData,
+  {
+    food: 'almond milk',
+    calories: 30,
+    carbs: 1.0,
+    protein: 1.0,
+    fat: 2.5,
+  },
+  {
+    food: 'soy milk',
+    calories: 80,
+    carbs: 4.0,
+    protein: 7.0,
+    fat: 4.0,
+  },
+  {
+    food: 'rice milk',
+    calories: 120,
+    carbs: 22.0,
+    protein: 1.0,
+    fat: 2.5,
+  },
+  {
+    food: 'coconut milk',
+    calories: 45,
+    carbs: 2.0,
+    protein: 0.5,
+    fat: 4.5,
+  },
+  {
+    food: 'oat milk',
+    calories: 120,
+    carbs: 16.0,
+    protein: 3.0,
+    fat: 5.0,
+  },
+  {
+    food: 'hemp milk',
+    calories: 70,
+    carbs: 1.0,
+    protein: 3.0,
+    fat: 6.0,
+  },
+  {
+    food: 'cashew milk',
+    calories: 25,
+    carbs: 1.0,
+    protein: 1.0,
+    fat: 2.0,
+  },
+  {
+    food: 'pea milk',
+    calories: 70,
+    carbs: 0.0,
+    protein: 8.0,
+    fat: 4.5,
+  },
+  {
+    food: 'goat milk',
+    calories: 168,
+    carbs: 11.0,
+    protein: 9.0,
+    fat: 10.0,
+  },
+  {
+    food: 'camel milk',
+    calories: 107,
+    carbs: 5.8,
+    protein: 5.2,
+    fat: 4.5,
+  },
+  {
+    food: 'buffalo milk',
+    calories: 237,
+    carbs: 12.0,
+    protein: 9.0,
+    fat: 16.0,
+  },
+]
+
 export const Default = {
   args: {
     data: sampleData,
@@ -98,16 +185,14 @@ export const ChangeOrderUsingHeader = {
 
 export const HasTitleAndDescription = {
   args: {
-    title: 'Nutrient Data Comparison Across Various Types of Milk',
-    description:
-      'This table illustrates the variations in calories and nutrients for different types of milk, with measurements based on a serving size of 250 ml. Caloric values are expressed in kCal, and nutrient quantities are measured in grams. The data is sourced from the Canadian Nutrient File.',
+    ...textData,
     data: sampleData,
   },
 }
 
 export const CustomizeHeaders = {
   args: {
-    title: 'Nutrient Data Comparison Across Various Types of Milk',
+    ...textData,
     headers: [
       { dataKey: 'food', label: 'type (per 250ml)' },
       { dataKey: 'calories', label: 'calories (kCal)' },
@@ -115,9 +200,16 @@ export const CustomizeHeaders = {
       { dataKey: 'protein', label: 'protein (g)' },
       { dataKey: 'fat', label: 'fat (g)' },
     ],
-    description:
-      'This table illustrates the variations in calories and nutrients for different types of milk, with measurements based on a serving size of 250 ml. Caloric values are expressed in kCal, and nutrient quantities are measured in grams. The data is sourced from the Canadian Nutrient File.',
     data: sampleData,
+  },
+}
+
+export const WithPagination = {
+  args: {
+    ...textData,
+    data: manyDataRows,
+    // eslint-disable-next-line no-magic-numbers
+    rowsPerPageOptions: [5, 10, 15],
   },
 }
 

--- a/src/components/table/table.stories.tsx
+++ b/src/components/table/table.stories.tsx
@@ -208,8 +208,6 @@ export const WithPagination = {
   args: {
     ...textData,
     data: manyDataRows,
-    // eslint-disable-next-line no-magic-numbers
-    rowsPerPageOptions: [5, 10, 15],
   },
 }
 

--- a/src/components/table/table.tsx
+++ b/src/components/table/table.tsx
@@ -116,11 +116,11 @@ export default function Table(props: TableData) {
             },
           }}
           classes={{
-            toolbar: 'rustic-toolbar',
-            input: 'rustic-input',
-            spacer: 'rustic-spacer',
-            displayedRows: 'rustic-displayed-rows',
-            actions: 'rustic-actions',
+            toolbar: 'rustic-table-toolbar',
+            input: 'rustic-table-input',
+            spacer: 'rustic-table-spacer',
+            displayedRows: 'rustic-table-displayed-rows',
+            actions: 'rustic-table-actions',
           }}
         />
       )}

--- a/src/components/table/table.tsx
+++ b/src/components/table/table.tsx
@@ -14,10 +14,12 @@ import React, { useState } from 'react'
 import { capitalizeFirstLetter } from '../helper'
 import type { TableData, TableHeader } from '../types'
 
+const paginationThreshold = 10
+
 export default function Table(props: TableData) {
   const [page, setPage] = useState(0)
   const [rowsPerPage, setRowsPerPage] = useState(
-    props.rowsPerPageOptions ? props.rowsPerPageOptions[0] : -1
+    props.data.length <= paginationThreshold ? -1 : paginationThreshold
   )
 
   if (props.data.length === 0) {
@@ -91,14 +93,13 @@ export default function Table(props: TableData) {
           </TableBody>
         </MuiTable>
       </TableContainer>
-      {props.rowsPerPageOptions && (
+      {props.data.length > paginationThreshold && (
         <TablePagination
           className="rustic-table-pagination"
           data-cy="table-pagination"
           component="div"
           count={props.data.length}
           rowsPerPage={rowsPerPage}
-          rowsPerPageOptions={props.rowsPerPageOptions}
           page={page}
           onPageChange={handleChangePage}
           onRowsPerPageChange={handleChangeRowsPerPage}

--- a/src/components/table/table.tsx
+++ b/src/components/table/table.tsx
@@ -137,6 +137,7 @@ export default function Table(props: TableData) {
                 flex: 1,
                 display: 'flex',
                 justifyContent: 'flex-end',
+                whiteSpace: 'nowrap',
               },
             }),
           }}

--- a/src/components/table/table.tsx
+++ b/src/components/table/table.tsx
@@ -120,12 +120,18 @@ export default function Table(props: TableData) {
             '& .MuiTablePagination-selectLabel': {
               color: theme.palette.text.disabled,
             },
+            '& .MuiTablePagination-input': {
+              marginLeft: 0,
+            },
             ...(isMobile && {
               '& .MuiTablePagination-spacer': {
                 position: 'absolute',
               },
               '& .MuiToolbar-root': {
                 padding: 0,
+                '& .MuiTablePagination-actions': {
+                  marginLeft: 1,
+                },
               },
               '& .MuiTablePagination-displayedRows': {
                 flex: 1,

--- a/src/components/table/table.tsx
+++ b/src/components/table/table.tsx
@@ -1,5 +1,6 @@
 import './table.css'
 
+import { useMediaQuery, useTheme } from '@mui/material'
 import Stack from '@mui/material/Stack'
 import { default as MuiTable } from '@mui/material/Table'
 import TableBody from '@mui/material/TableBody'
@@ -17,14 +18,19 @@ import type { TableData, TableHeader } from '../types'
 const paginationThreshold = 10
 
 export default function Table(props: TableData) {
-  const [page, setPage] = useState(0)
+  const isDataGreaterThanThreshold = props.data.length > paginationThreshold
+
   const [rowsPerPage, setRowsPerPage] = useState(
-    props.data.length <= paginationThreshold ? -1 : paginationThreshold
+    isDataGreaterThanThreshold ? paginationThreshold : -1
   )
+  const [currentPage, setCurrentPage] = useState(0)
 
   if (props.data.length === 0) {
     return <Typography variant="body2">No data available</Typography>
   }
+
+  const theme = useTheme()
+  const isMobile = useMediaQuery(theme.breakpoints.down('md'))
 
   const dataKeys = Array.from(
     new Set(props.data.flatMap((rowData) => Object.keys(rowData)))
@@ -34,16 +40,22 @@ export default function Table(props: TableData) {
 
   const dataToDisplay =
     rowsPerPage > 0
-      ? props.data.slice(page * rowsPerPage, page * rowsPerPage + rowsPerPage)
+      ? props.data.slice(
+          currentPage * rowsPerPage,
+          currentPage * rowsPerPage + rowsPerPage
+        )
       : props.data
 
-  function handleChangePage(event: unknown, newPage: number) {
-    setPage(newPage)
+  function handleChangePage(
+    event: React.MouseEvent<HTMLButtonElement, MouseEvent> | null,
+    newPage: number
+  ) {
+    setCurrentPage(newPage)
   }
 
   function handleChangeRowsPerPage(event: React.ChangeEvent<HTMLInputElement>) {
     setRowsPerPage(+event.target.value)
-    setPage(0)
+    setCurrentPage(0)
   }
 
   return (
@@ -93,16 +105,35 @@ export default function Table(props: TableData) {
           </TableBody>
         </MuiTable>
       </TableContainer>
-      {props.data.length > paginationThreshold && (
+      {isDataGreaterThanThreshold && (
         <TablePagination
           className="rustic-table-pagination"
           data-cy="table-pagination"
           component="div"
           count={props.data.length}
           rowsPerPage={rowsPerPage}
-          page={page}
+          labelRowsPerPage="Rows:"
+          page={currentPage}
           onPageChange={handleChangePage}
           onRowsPerPageChange={handleChangeRowsPerPage}
+          sx={{
+            '& .MuiTablePagination-selectLabel': {
+              color: theme.palette.text.disabled,
+            },
+            ...(isMobile && {
+              '& .MuiTablePagination-spacer': {
+                position: 'absolute',
+              },
+              '& .MuiToolbar-root': {
+                padding: 0,
+              },
+              '& .MuiTablePagination-displayedRows': {
+                flex: 1,
+                display: 'flex',
+                justifyContent: 'flex-end',
+              },
+            }),
+          }}
         />
       )}
     </Stack>

--- a/src/components/table/table.tsx
+++ b/src/components/table/table.tsx
@@ -1,6 +1,6 @@
 import './table.css'
 
-import { useMediaQuery, useTheme } from '@mui/material'
+import { useTheme } from '@mui/material'
 import Stack from '@mui/material/Stack'
 import { default as MuiTable } from '@mui/material/Table'
 import TableBody from '@mui/material/TableBody'
@@ -18,10 +18,10 @@ import type { TableData, TableHeader } from '../types'
 const paginationThreshold = 10
 
 export default function Table(props: TableData) {
-  const isDataGreaterThanThreshold = props.data.length > paginationThreshold
+  const isPaginationEnabled = props.data.length > paginationThreshold
 
   const [rowsPerPage, setRowsPerPage] = useState(
-    isDataGreaterThanThreshold ? paginationThreshold : -1
+    isPaginationEnabled ? paginationThreshold : -1
   )
   const [currentPage, setCurrentPage] = useState(0)
 
@@ -30,7 +30,6 @@ export default function Table(props: TableData) {
   }
 
   const theme = useTheme()
-  const isMobile = useMediaQuery(theme.breakpoints.down('md'))
 
   const dataKeys = Array.from(
     new Set(props.data.flatMap((rowData) => Object.keys(rowData)))
@@ -38,20 +37,12 @@ export default function Table(props: TableData) {
   const headers: TableHeader[] =
     props.headers || dataKeys.map((key) => ({ dataKey: key }))
 
-  const dataToDisplay =
-    rowsPerPage > 0
-      ? props.data.slice(
-          currentPage * rowsPerPage,
-          currentPage * rowsPerPage + rowsPerPage
-        )
-      : props.data
+  const dataOfCurrentPage = props.data.slice(
+    currentPage * rowsPerPage,
+    currentPage * rowsPerPage + rowsPerPage
+  )
 
-  function handleChangePage(
-    event: React.MouseEvent<HTMLButtonElement, MouseEvent> | null,
-    newPage: number
-  ) {
-    setCurrentPage(newPage)
-  }
+  const dataToDisplay = rowsPerPage > 0 ? dataOfCurrentPage : props.data
 
   function handleChangeRowsPerPage(event: React.ChangeEvent<HTMLInputElement>) {
     setRowsPerPage(+event.target.value)
@@ -105,7 +96,7 @@ export default function Table(props: TableData) {
           </TableBody>
         </MuiTable>
       </TableContainer>
-      {isDataGreaterThanThreshold && (
+      {isPaginationEnabled && (
         <TablePagination
           className="rustic-table-pagination"
           data-cy="table-pagination"
@@ -114,32 +105,22 @@ export default function Table(props: TableData) {
           rowsPerPage={rowsPerPage}
           labelRowsPerPage="Rows:"
           page={currentPage}
-          onPageChange={handleChangePage}
+          onPageChange={(
+            event: React.MouseEvent<HTMLButtonElement, MouseEvent> | null,
+            newPage: number
+          ) => setCurrentPage(newPage)}
           onRowsPerPageChange={handleChangeRowsPerPage}
           sx={{
             '& .MuiTablePagination-selectLabel': {
               color: theme.palette.text.disabled,
             },
-            '& .MuiTablePagination-input': {
-              marginLeft: 0,
-            },
-            ...(isMobile && {
-              '& .MuiTablePagination-spacer': {
-                position: 'absolute',
-              },
-              '& .MuiToolbar-root': {
-                padding: 0,
-                '& .MuiTablePagination-actions': {
-                  marginLeft: 1,
-                },
-              },
-              '& .MuiTablePagination-displayedRows': {
-                flex: 1,
-                display: 'flex',
-                justifyContent: 'flex-end',
-                whiteSpace: 'nowrap',
-              },
-            }),
+          }}
+          classes={{
+            toolbar: 'rustic-toolbar',
+            input: 'rustic-input',
+            spacer: 'rustic-spacer',
+            displayedRows: 'rustic-displayed-rows',
+            actions: 'rustic-actions',
           }}
         />
       )}

--- a/src/components/table/table.tsx
+++ b/src/components/table/table.tsx
@@ -1,6 +1,6 @@
 import './table.css'
 
-import Box from '@mui/material/Box'
+import Stack from '@mui/material/Stack'
 import { default as MuiTable } from '@mui/material/Table'
 import TableBody from '@mui/material/TableBody'
 import TableCell from '@mui/material/TableCell'
@@ -45,10 +45,10 @@ export default function Table(props: TableData) {
   }
 
   return (
-    <Box className="rustic-table">
+    <Stack className="rustic-table" spacing={1}>
       {props.title && (
         <Typography
-          variant="body1"
+          variant="h6"
           data-cy="table-title"
           className="rustic-table-title"
         >
@@ -56,7 +56,7 @@ export default function Table(props: TableData) {
         </Typography>
       )}
       {props.description && (
-        <Typography variant="subtitle2" data-cy="table-description">
+        <Typography variant="body1" data-cy="table-description">
           {props.description}
         </Typography>
       )}
@@ -104,6 +104,6 @@ export default function Table(props: TableData) {
           onRowsPerPageChange={handleChangeRowsPerPage}
         />
       )}
-    </Box>
+    </Stack>
   )
 }

--- a/src/components/table/table.tsx
+++ b/src/components/table/table.tsx
@@ -6,14 +6,20 @@ import TableBody from '@mui/material/TableBody'
 import TableCell from '@mui/material/TableCell'
 import TableContainer from '@mui/material/TableContainer'
 import TableHead from '@mui/material/TableHead'
+import TablePagination from '@mui/material/TablePagination'
 import TableRow from '@mui/material/TableRow'
 import Typography from '@mui/material/Typography'
-import React from 'react'
+import React, { useState } from 'react'
 
 import { capitalizeFirstLetter } from '../helper'
 import type { TableData, TableHeader } from '../types'
 
 export default function Table(props: TableData) {
+  const [page, setPage] = useState(0)
+  const [rowsPerPage, setRowsPerPage] = useState(
+    props.rowsPerPageOptions ? props.rowsPerPageOptions[0] : -1
+  )
+
   if (props.data.length === 0) {
     return <Typography variant="body2">No data available</Typography>
   }
@@ -23,6 +29,20 @@ export default function Table(props: TableData) {
   )
   const headers: TableHeader[] =
     props.headers || dataKeys.map((key) => ({ dataKey: key }))
+
+  const dataToDisplay =
+    rowsPerPage > 0
+      ? props.data.slice(page * rowsPerPage, page * rowsPerPage + rowsPerPage)
+      : props.data
+
+  function handleChangePage(event: unknown, newPage: number) {
+    setPage(newPage)
+  }
+
+  function handleChangeRowsPerPage(event: React.ChangeEvent<HTMLInputElement>) {
+    setRowsPerPage(+event.target.value)
+    setPage(0)
+  }
 
   return (
     <Box className="rustic-table">
@@ -40,8 +60,12 @@ export default function Table(props: TableData) {
           {props.description}
         </Typography>
       )}
-      <TableContainer>
-        <MuiTable aria-label={props.title || 'a table of data'} size="small">
+      <TableContainer className="rustic-table-container">
+        <MuiTable
+          aria-label={props.title || 'a table of data'}
+          size="small"
+          stickyHeader
+        >
           {headers.length > 0 && (
             <TableHead>
               <TableRow>
@@ -55,7 +79,7 @@ export default function Table(props: TableData) {
           )}
 
           <TableBody>
-            {props.data.map((rowData, rowIndex) => (
+            {dataToDisplay.map((rowData, rowIndex) => (
               <TableRow key={`row-${rowIndex}`}>
                 {headers.map((header, colIndex) => (
                   <TableCell key={`cell-${rowIndex}-${colIndex}`}>
@@ -67,6 +91,19 @@ export default function Table(props: TableData) {
           </TableBody>
         </MuiTable>
       </TableContainer>
+      {props.rowsPerPageOptions && (
+        <TablePagination
+          className="rustic-table-pagination"
+          data-cy="table-pagination"
+          component="div"
+          count={props.data.length}
+          rowsPerPage={rowsPerPage}
+          rowsPerPageOptions={props.rowsPerPageOptions}
+          page={page}
+          onPageChange={handleChangePage}
+          onRowsPerPageChange={handleChangeRowsPerPage}
+        />
+      )}
     </Box>
   )
 }

--- a/src/components/types.ts
+++ b/src/components/types.ts
@@ -134,6 +134,8 @@ export interface TableFormat extends DataFormat {
   /** Optional array to set the order of columns and assign labels.
    * This can also be used to limit which columns are shown. */
   headers?: TableHeader[]
+  /** Options to display in a rows per page dropdown. Provide a value to enable pagination. The first index number will be initially shown. */
+  rowsPerPageOptions?: number[]
 }
 
 export type TableData = TableFormat & Updates<TableFormat>

--- a/src/components/types.ts
+++ b/src/components/types.ts
@@ -134,8 +134,6 @@ export interface TableFormat extends DataFormat {
   /** Optional array to set the order of columns and assign labels.
    * This can also be used to limit which columns are shown. */
   headers?: TableHeader[]
-  /** Options to display in a rows per page dropdown. Provide a value to enable pagination. The first index number will be initially shown. */
-  rowsPerPageOptions?: number[]
 }
 
 export type TableData = TableFormat & Updates<TableFormat>


### PR DESCRIPTION
## Changes
- add pagination
- update title and description to match design

Will follow up with api calls to account for large data sets.

Addresses issue #173.

## Screenshots
### Design
<img width="525" alt="Screenshot 2024-05-29 at 10 12 02 AM" src="https://github.com/rustic-ai/ui-components/assets/111031789/26662b95-5f35-4688-baa7-6f0568c3b61e">

### Before
<img width="681" alt="Screenshot 2024-05-29 at 10 17 07 AM" src="https://github.com/rustic-ai/ui-components/assets/111031789/8895251e-302e-4ca3-b7fd-bf26dd381b25">

### After
#### Desktop
<img width="876" alt="Screenshot 2024-05-30 at 1 45 40 PM" src="https://github.com/rustic-ai/ui-components/assets/111031789/824cab16-580d-4750-a5a7-3f5629d468db">

![table-desktop](https://github.com/rustic-ai/ui-components/assets/111031789/1dc3ce45-a20d-4de3-bb33-ca838ec6e6c6)


#### Mobile
<img width="402" alt="Screenshot 2024-05-30 at 1 44 19 PM" src="https://github.com/rustic-ai/ui-components/assets/111031789/e5a1a8de-b430-4cbd-a261-572fe8116067">

![table-mobile](https://github.com/rustic-ai/ui-components/assets/111031789/ef6b8ea7-7a47-46f6-9056-025a702f28a8)

