### PR TITLE
fix(transcript): remove transcript header

### DIFF
--- a/src/components/media/transcript/transcript.css
+++ b/src/components/media/transcript/transcript.css
@@ -1,23 +1,14 @@
 .rustic-transcript-container {
-  padding-top: 16px;
-  overflow-y: scroll;
-}
-
-.rustic-transcript-header {
   display: flex;
-  padding-bottom: 10px;
+  gap: 16px;
+  margin-top: 16px;
 }
 
-.rustic-transcript-header hr {
+.rustic-transcript-container hr {
   border-right-width: medium;
-  height: 21px;
-}
-
-.rustic-transcript-header span {
-  padding-left: 14px;
-  line-height: 1.5;
 }
 
 .rustic-transcript-content {
   max-height: 25vh;
+  overflow-y: scroll;
 }

--- a/src/components/media/transcript/transcript.tsx
+++ b/src/components/media/transcript/transcript.tsx
@@ -14,14 +14,7 @@ export default function Transcript(props: TranscriptProps) {
 
   return (
     <Box className="rustic-transcript-container">
-      {!isFullscreen && (
-        <Box className="rustic-transcript-header">
-          <Divider orientation="vertical" flexItem />
-          <Typography variant="overline" color="text.secondary">
-            Transcript
-          </Typography>
-        </Box>
-      )}
+      {!isFullscreen && <Divider orientation="vertical" flexItem />}
       <Typography
         className="rustic-transcript-content"
         data-cy="transcript"


### PR DESCRIPTION
## Changes
- remove transcript header

Addresses issue #170.

## Screenshots
### Before
<img width="918" alt="Screenshot 2024-05-31 at 3 10 53 PM" src="https://github.com/rustic-ai/ui-components/assets/111031789/0c8eaa64-6688-4d4b-a853-982b736ca1ba">
<img width="769" alt="Screenshot 2024-05-31 at 3 11 22 PM" src="https://github.com/rustic-ai/ui-components/assets/111031789/57d02a2d-3658-4b2c-8ea6-ae41e096b171">

### After
<img width="918" alt="Screenshot 2024-05-31 at 3 10 37 PM" src="https://github.com/rustic-ai/ui-components/assets/111031789/ff614675-3a06-4616-b5e9-0b1b76467b32">
<img width="767" alt="Screenshot 2024-05-31 at 3 10 10 PM" src="https://github.com/rustic-ai/ui-components/assets/111031789/366a8630-9c05-49f0-a8e6-1d8d912efad4">
