### PR TITLE
fix(popoverMenu): reduce menu's min-width

### DIFF
--- a/src/components/menu/popoverMenu.css
+++ b/src/components/menu/popoverMenu.css
@@ -1,6 +1,6 @@
 .rustic-popover-menu ul {
   padding: 0;
-  min-width: 240px;
+  min-width: 100px;
 }
 
 .rustic-popover-menu li {


### PR DESCRIPTION
## Change
- Reduce menu's min-width to avoid having extra space when menu item label is short

## Before
![Screenshot 2024-05-31 at 10 11 15 PM](https://github.com/rustic-ai/ui-components/assets/103023797/73d562ac-d1c9-4c62-9d3c-434d17d3d43a)

## After
![Screenshot 2024-05-31 at 10 10 35 PM](https://github.com/rustic-ai/ui-components/assets/103023797/11c26cf2-40d1-4939-9e31-79ce36650eab)
