### PR TITLE
fix(popoverMenu): add tooltip for icon button

### DIFF
--- a/src/components/menu/popoverMenu.stories.tsx
+++ b/src/components/menu/popoverMenu.stories.tsx
@@ -150,42 +150,42 @@ const noDecoratorsMenuItems = [
 export const Default = {
   args: {
     menuItems: defaultMenuItems,
-    ariaLabel: 'open default menu',
+    ariaLabel: 'Open menu',
   },
 }
 
 export const EndDecorator = {
   args: {
     menuItems: endDecoratorMenuItems,
-    ariaLabel: 'open menu showing end decorators',
+    ariaLabel: 'Open menu',
   },
 }
 
 export const StartAndEndDecorators = {
   args: {
     menuItems: startAndEndDecoratorMenuItems,
-    ariaLabel: 'open menu showing start and end decorators',
+    ariaLabel: 'Open menu',
   },
 }
 
 export const TextDecorator = {
   args: {
     menuItems: textDecorator,
-    ariaLabel: 'open menu showing text decorators',
+    ariaLabel: 'Open menu',
   },
 }
 
 export const NoDecorators = {
   args: {
     menuItems: noDecoratorsMenuItems,
-    ariaLabel: 'open menu showing no decorators',
+    ariaLabel: 'Open menu',
   },
 }
 
 export const WithCustomButtonIcon = {
   args: {
     menuItems: defaultMenuItems,
-    ariaLabel: 'open menu showing custom button icon',
+    ariaLabel: 'Open menu',
     icon: listIcon,
   },
 }
@@ -193,7 +193,7 @@ export const WithCustomButtonIcon = {
 export const WithCustomButtonText = {
   args: {
     menuItems: defaultMenuItems,
-    ariaLabel: 'open menu showing custom button text',
+    ariaLabel: 'Open menu',
     buttonText: 'Menu',
   },
 }
@@ -201,7 +201,7 @@ export const WithCustomButtonText = {
 export const WithCustomButtonIconAndText = {
   args: {
     menuItems: defaultMenuItems,
-    ariaLabel: 'open menu showing custom button icon and text',
+    ariaLabel: 'Open menu',
     icon: listIcon,
     buttonText: 'Menu',
   },
@@ -215,7 +215,7 @@ export const WithLink = {
         href: 'https://www.rustic.ai',
       },
     ],
-    ariaLabel: 'open default menu',
+    ariaLabel: 'Open menu',
   },
 }
 
@@ -228,6 +228,6 @@ export const WithDownloadLink = {
         isFiledownload: true,
       },
     ],
-    ariaLabel: 'open default menu',
+    ariaLabel: 'Open menu',
   },
 }

--- a/src/components/menu/popoverMenu.tsx
+++ b/src/components/menu/popoverMenu.tsx
@@ -8,6 +8,7 @@ import ListItemText from '@mui/material/ListItemText'
 import Menu from '@mui/material/Menu'
 import MenuItem from '@mui/material/MenuItem'
 import { useTheme } from '@mui/material/styles'
+import Tooltip from '@mui/material/Tooltip'
 import Typography from '@mui/material/Typography'
 import { Box } from '@mui/system'
 import type { ReactNode } from 'react'
@@ -144,9 +145,11 @@ export default function PopoverMenu(props: PopoverMenuProps) {
       )
     } else {
       return (
-        <IconButton {...buttonAttributes} data-cy="menu-icon-button">
-          {props.icon ? props.icon : defaultIcon}
-        </IconButton>
+        <Tooltip title={props.ariaLabel}>
+          <IconButton {...buttonAttributes} data-cy="menu-icon-button">
+            {props.icon ? props.icon : defaultIcon}
+          </IconButton>
+        </Tooltip>
       )
     }
   }

--- a/src/components/visualization/vegaLiteViz/vegaLiteViz.cy.tsx
+++ b/src/components/visualization/vegaLiteViz/vegaLiteViz.cy.tsx
@@ -39,7 +39,7 @@ describe('VegaLiteViz', () => {
 
       cy.get('[data-cy="vega-lite"]').should('exist')
       cy.get('.rustic-vega-lite').should('exist')
-      cy.get('[aria-label="menu"]').click()
+      cy.get('[data-cy="menu-icon-button"]').click()
       cy.contains('Save as SVG').should('exist')
       cy.contains('Save as PNG').should('exist')
     })

--- a/src/components/visualization/vegaLiteViz/vegaLiteViz.tsx
+++ b/src/components/visualization/vegaLiteViz/vegaLiteViz.tsx
@@ -122,7 +122,7 @@ function VegaLiteViz(props: VegaLiteData) {
     return (
       <Stack direction="column" className="rustic-vega-lite-container">
         <Box justifyContent="end" display="flex">
-          <PopoverMenu menuItems={menuItems} ariaLabel="menu" />
+          <PopoverMenu menuItems={menuItems} ariaLabel="Download options" />
         </Box>
 
         {props.title && (


### PR DESCRIPTION
Resolves #158 

## Change:
- Add tooltip for icon button

(I wasn't sure if we want to add a props for tooltip label so I used `ariaLabel` for now)

## Screenshot
PopoverMenu example
![Screenshot 2024-06-01 at 10 02 56 PM](https://github.com/rustic-ai/ui-components/assets/103023797/fd2898fd-b547-4f8e-8d20-7988506a2dad)
VegaLite example
![Screenshot 2024-06-01 at 10 04 07 PM](https://github.com/rustic-ai/ui-components/assets/103023797/53bcdd9d-1c0c-45b0-8016-0446d7ea357b)

