### PR TITLE
fix(vegaLite): wrap long title

### DIFF
--- a/src/components/types.ts
+++ b/src/components/types.ts
@@ -146,9 +146,13 @@ type VegaLiteOptions = EmbedOptions<string, Renderers> & {
   }
 }
 
+export type VegaLiteSpec = VisualizationSpec & {
+  width?: 'container' | number
+}
+
 export interface VegaLiteFormat extends DataFormat {
   /** Follow Vega-lite's [documentation](https://vega.github.io/vega-lite/) to provide a specification object. Schema should be included in the spec. Need to use 'container' for width or height for responsive chart. */
-  spec: VisualizationSpec
+  spec: VegaLiteSpec
   theme: {
     light?: VegaLiteOptions['theme']
     dark: VegaLiteOptions['theme']

--- a/src/components/visualization/vegaLiteViz/vegaLiteViz.cy.tsx
+++ b/src/components/visualization/vegaLiteViz/vegaLiteViz.cy.tsx
@@ -1,8 +1,6 @@
-import type { VisualizationSpec } from 'vega-embed'
-
 import { supportedViewports } from '../../../../cypress/support/variables'
+import type { VegaLiteSpec } from '../../types'
 import VegaLiteViz from './vegaLiteViz'
-
 describe('VegaLiteViz', () => {
   beforeEach(() => {
     cy.mount(
@@ -56,7 +54,7 @@ describe('VegaLiteViz', () => {
         x: { field: 'a', type: 'nominal', axis: { labelAngle: 0 } },
         y: { field: 'b', type: 'quantitative' },
       },
-    } as VisualizationSpec
+    } as VegaLiteSpec
 
     it(`displays an error message if the spec is wrong on ${viewport} screen`, () => {
       cy.viewport(viewport)

--- a/src/components/visualization/vegaLiteViz/vegaLiteViz.stories.tsx
+++ b/src/components/visualization/vegaLiteViz/vegaLiteViz.stories.tsx
@@ -388,7 +388,6 @@ export const Map = {
       ],
     },
   },
-  // decorators,
 }
 
 export const GlobeVisualization = {
@@ -396,7 +395,6 @@ export const GlobeVisualization = {
     spec: {
       $schema: 'https://vega.github.io/schema/vega-lite/v5.json',
       title: ['Globe Visualization', 'of Earthquakes'],
-
       width: 'container',
       height: 300,
       projection: {


### PR DESCRIPTION
## Change:
- Wrap long title for small screens

Question: 
I wasn't sure if there's a better approach to fix long title. I need to use letter spacing, font family, font weight, and font size to calculate the length of title and switch lines when needed. However, VegaLite's default title styling has 1px for letterSpacing and they don't provide props to change it. People could change it through css className, but then we don't have access to this info when calculating the title width.

(I will fix long axis label after this PR. The same approach will be used)

## Before
<img width="318" alt="Screenshot 2024-06-03 at 1 05 53 PM" src="https://github.com/rustic-ai/ui-components/assets/103023797/c8dc795a-d20a-4d49-9615-658781e37588">

## After
<img width="332" alt="Screenshot 2024-06-03 at 1 05 59 PM" src="https://github.com/rustic-ai/ui-components/assets/103023797/c61c5831-1098-4c14-a3ef-75d8a952575b">
