### PR TITLE
fix(PopoverMenu): allow customizing icon position

### DIFF
--- a/src/components/menu/popoverMenu.stories.tsx
+++ b/src/components/menu/popoverMenu.stories.tsx
@@ -40,6 +40,14 @@ meta.argTypes = {
       },
     },
   },
+  iconPosition: {
+    table: {
+      type: {
+        summary: 'IconPosition.\n',
+        detail: 'Choose between `start` and `end` for positioning the icon.\n',
+      },
+    },
+  },
 }
 
 const pinIcon = <Icon name="keep" />
@@ -198,12 +206,22 @@ export const WithCustomButtonText = {
   },
 }
 
-export const WithCustomButtonIconAndText = {
+export const WithTextAndStartIcon = {
   args: {
     menuItems: defaultMenuItems,
     ariaLabel: 'Open menu',
     icon: listIcon,
     buttonText: 'Menu',
+  },
+}
+
+export const WithTextAndEndIcon = {
+  args: {
+    menuItems: defaultMenuItems,
+    ariaLabel: 'Open menu',
+    icon: listIcon,
+    buttonText: 'Menu',
+    iconPosition: 'end',
   },
 }
 

--- a/src/components/menu/popoverMenu.tsx
+++ b/src/components/menu/popoverMenu.tsx
@@ -26,12 +26,16 @@ export interface PopoverMenuItem {
   endDecorator?: ReactNode
 }
 
+type IconPosition = 'start' | 'end'
+
 export interface PopoverMenuProps {
   menuItems: PopoverMenuItem[]
   /** Aria-label to describe the button for assistive technology. */
   ariaLabel: string
   /** Provide your own customized icon. */
   icon?: ReactNode
+  /** Specify the position of the icon. */
+  iconPosition?: IconPosition
   /** Text to display on the button. */
   buttonText?: string
 }
@@ -133,11 +137,13 @@ export default function PopoverMenu(props: PopoverMenuProps) {
 
     const defaultIcon = <Icon name="more_vert" />
 
+    const menuIcon = props.icon ? props.icon : null
     if (props.buttonText) {
       return (
         <Button
           {...buttonAttributes}
-          startIcon={props.icon ? props.icon : null}
+          startIcon={props.iconPosition === 'start' && menuIcon}
+          endIcon={props.iconPosition === 'end' && menuIcon}
           data-cy="menu-button"
         >
           {props.buttonText}
@@ -178,4 +184,8 @@ export default function PopoverMenu(props: PopoverMenuProps) {
       </PopoverMenuElement>
     </>
   )
+}
+
+PopoverMenu.defaultProps = {
+  iconPosition: 'start' as IconPosition,
 }


### PR DESCRIPTION
## Change
- Allow customizing icon position for the menu button

I added `IconPosition` because in the table component, we want to click column header to open a popover menu and the header has an expand icon next to it. I wanted to avoid changing the `icon` props we have right now, so I added `IconPosition` instead

<img width="49" alt="Screenshot 2024-06-03 at 4 06 17 PM" src="https://github.com/rustic-ai/ui-components/assets/103023797/38820d4b-724d-4909-ba07-047c918eb1ce">
=>
<img width="103" alt="Screenshot 2024-06-03 at 4 06 22 PM" src="https://github.com/rustic-ai/ui-components/assets/103023797/18532677-61f5-41c6-a92a-74161204dfa9">


## Screenshots
<img width="1065" alt="Screenshot 2024-06-03 at 4 05 14 PM" src="https://github.com/rustic-ai/ui-components/assets/103023797/bd1263ef-9495-4b92-aabc-d3604e9cfd2c">

