### PR TITLE
fix(PopoverMenu): fix styling

### DIFF
--- a/src/components/menu/popoverMenu.css
+++ b/src/components/menu/popoverMenu.css
@@ -14,3 +14,7 @@
 .rustic-popover-menu-item-start-icon {
   margin-right: 8px;
 }
+
+.rustic-popover-menu-item-end-icon {
+  margin-left: 32px;
+}

--- a/src/components/menu/popoverMenu.css
+++ b/src/components/menu/popoverMenu.css
@@ -1,6 +1,7 @@
 .rustic-popover-menu ul {
   padding: 0;
   min-width: 100px;
+  max-width: 240px;
 }
 
 .rustic-popover-menu li {
@@ -16,5 +17,5 @@
 }
 
 .rustic-popover-menu-item-end-icon {
-  margin-left: 32px;
+  margin-left: 80px;
 }

--- a/src/components/menu/popoverMenu.stories.tsx
+++ b/src/components/menu/popoverMenu.stories.tsx
@@ -42,7 +42,7 @@ meta.argTypes = {
 }
 
 const pinIcon = <Icon name="keep" />
-const addBoxIcon = <Icon name="add_box" />
+const addCircleIcon = <Icon name="add_circle" />
 const deleteIcon = <Icon name="delete" />
 const thermostatIcon = <Icon name="device_thermostat" />
 const listIcon = <Icon name="list" />
@@ -103,13 +103,13 @@ const startAndEndDecoratorMenuItems = [
     label: 'Celsius',
     onClick: () => {},
     startDecorator: thermostatIcon,
-    endDecorator: addBoxIcon,
+    endDecorator: addCircleIcon,
   },
   {
     label: 'Fahrenheit',
     onClick: () => {},
     startDecorator: thermostatIcon,
-    endDecorator: addBoxIcon,
+    endDecorator: addCircleIcon,
   },
 ]
 

--- a/src/components/menu/popoverMenu.stories.tsx
+++ b/src/components/menu/popoverMenu.stories.tsx
@@ -1,5 +1,4 @@
 import Typography from '@mui/material/Typography'
-import Box from '@mui/system/Box'
 import type { Meta } from '@storybook/react'
 import React from 'react'
 
@@ -43,11 +42,7 @@ meta.argTypes = {
 }
 
 const pinIcon = <Icon name="keep" />
-const addBoxIcon = (
-  <Box sx={{ color: 'secondary.main' }}>
-    <Icon name="add_box" />
-  </Box>
-)
+const addBoxIcon = <Icon name="add_box" />
 const deleteIcon = <Icon name="delete" />
 const thermostatIcon = <Icon name="device_thermostat" />
 const listIcon = <Icon name="list" />
@@ -85,24 +80,21 @@ const defaultMenuItems = [
   },
 ]
 
-const renderPinIconWithColor = (
-  <Box sx={{ color: 'secondary.main' }}>{pinIcon}</Box>
-)
 const endDecoratorMenuItems = [
   {
     label: 'Charts',
     onClick: () => {},
-    endDecorator: renderPinIconWithColor,
+    endDecorator: pinIcon,
   },
   {
     label: 'Graphs',
     onClick: () => {},
-    endDecorator: renderPinIconWithColor,
+    endDecorator: pinIcon,
   },
   {
     label: 'Marketing',
     onClick: () => {},
-    endDecorator: renderPinIconWithColor,
+    endDecorator: pinIcon,
   },
 ]
 

--- a/src/components/menu/popoverMenu.tsx
+++ b/src/components/menu/popoverMenu.tsx
@@ -76,7 +76,7 @@ export default function PopoverMenu(props: PopoverMenuProps) {
         {menuItem.endDecorator && (
           <Box
             sx={{ color: 'secondary.main' }}
-            className="rustic-popover-menu-item-icon"
+            className="rustic-popover-menu-item-icon  rustic-popover-menu-item-end-icon"
           >
             {menuItem.endDecorator}
           </Box>


### PR DESCRIPTION
## Change
- Fix styling for menu item end decorators

## Screenshots
### Before
<img width="295" alt="Screenshot 2024-06-04 at 8 57 11 AM" src="https://github.com/rustic-ai/ui-components/assets/103023797/28b70239-197f-4a98-b17a-663d390110da">

### After
<img width="299" alt="Screenshot 2024-06-04 at 4 56 37 PM" src="https://github.com/rustic-ai/ui-components/assets/103023797/85361e82-486a-4be3-86f1-036305290244">
