### PR TITLE
fix(table): update theme to match design

### DIFF
--- a/src/rusticTheme.ts
+++ b/src/rusticTheme.ts
@@ -3,6 +3,7 @@ import type { Shadows } from '@mui/material/styles'
 import { createTheme, responsiveFontSizes } from '@mui/material/styles'
 import { deepmerge } from '@mui/utils'
 
+const blackColor = '#000000'
 const whiteColor = '#FFFFFF'
 const SecondaryMainColor = '#FF6928'
 const SecondaryDarkColor = '#E54500'
@@ -110,7 +111,7 @@ const baseTheme = createTheme({
   },
   palette: {
     common: {
-      black: '#000000',
+      black: blackColor,
       white: whiteColor,
     },
     error: {
@@ -139,6 +140,31 @@ const baseTheme = createTheme({
       }
     }),
   ] as Shadows,
+  components: {
+    MuiTableCell: {
+      styleOverrides: {
+        head: {
+          backgroundColor: actionFocusColor,
+        },
+        root: {
+          borderBottom: `1px solid ${dividerColor}`,
+          padding: '8px 16px',
+        },
+      },
+    },
+    MuiTableSortLabel: {
+      styleOverrides: {
+        root: {
+          '&.Mui-active': {
+            color: blackColor,
+            '& .MuiTableSortLabel-icon': {
+              color: blackColor,
+            },
+          },
+        },
+      },
+    },
+  },
 })
 
 const lightModePrimaryMainColor = '#3D3834'


### PR DESCRIPTION
Resolves #172 

## Change 
- Update theme for table to match design 

## Design
<img width="389" alt="Screenshot 2024-06-09 at 10 19 04 AM" src="https://github.com/rustic-ai/ui-components/assets/103023797/602b86ea-e830-4555-b4ca-94d6b8dc2767">

## Before
<img width="583" alt="Screenshot 2024-06-09 at 10 17 56 AM" src="https://github.com/rustic-ai/ui-components/assets/103023797/eac1ee84-dc94-4a5c-9fb2-9418f54aec58">
<img width="585" alt="Screenshot 2024-06-09 at 10 18 04 AM" src="https://github.com/rustic-ai/ui-components/assets/103023797/cd918507-bade-401a-bbb4-a6becff803a3">

## After
![Screenshot 2024-06-08 at 3 17 23 PM](https://github.com/rustic-ai/ui-components/assets/103023797/aeb49cba-b8d3-42fa-a6d2-0fa263506fb5)
![Screenshot 2024-06-08 at 3 17 14 PM](https://github.com/rustic-ai/ui-components/assets/103023797/0c159350-e60d-4c64-8623-a61a7ace5922)
