### PR TITLE
docs(messageCanvas): update getProfileComponent prop description

### DIFF
--- a/src/components/messageCanvas/messageCanvas.tsx
+++ b/src/components/messageCanvas/messageCanvas.tsx
@@ -9,7 +9,7 @@ import Timestamp from '../timestamp/timestamp'
 import type { ThreadableMessage } from '../types'
 
 export interface MessageContainerProps {
-  /** Profile icon to be shown before sender's name. */
+  /** A function that returns a React element to display sender details, like names and/or avatars. */
   getProfileComponent?: (message: ThreadableMessage) => ReactNode
   /** A function that returns a single React element which may be composed of several actions supported for the message, such as editing, copying, and deleting, etc.
    * In case no actions are applicable or available for a particular message, the function may return `undefined`.


### PR DESCRIPTION
## Changes
- update getProfileComponent prop description

## Screenshots
### Before
<img width="1032" alt="Screenshot 2024-06-15 at 4 03 50 AM" src="https://github.com/rustic-ai/ui-components/assets/111031789/f5f4073e-de29-47ba-8994-b56b1a6eab3a">

### After
<img width="1032" alt="Screenshot 2024-06-15 at 4 03 38 AM" src="https://github.com/rustic-ai/ui-components/assets/111031789/18168770-d213-4b2e-9ca2-e3fbc743fbbf">
