### PR TITLE
docs(question): add getProfileComponent to story

### DIFF
--- a/src/components/question/question.stories.tsx
+++ b/src/components/question/question.stories.tsx
@@ -1,6 +1,8 @@
+import Typography from '@mui/material/Typography'
 import type { Meta, StoryFn } from '@storybook/react'
 import React, { useState } from 'react'
 
+import Icon from '../icon/icon'
 import MessageCanvas from '../messageCanvas/messageCanvas'
 import Text from '../text/text'
 import type { Message } from '../types'
@@ -41,6 +43,22 @@ export default meta
 const options = ['Yes', 'Maybe', 'No']
 
 const agent = { name: 'Some Agent', id: 't671hjlk' }
+const user = { name: 'Some User', id: 'gahjqj19' }
+
+function getProfileIconAndName(name: string) {
+  return (
+    <>
+      {name.toLowerCase().includes('agent') ? (
+        <Icon name="smart_toy" />
+      ) : (
+        <Icon name="account_circle" />
+      )}
+      <Typography variant="body1" color="text.secondary">
+        {name}
+      </Typography>
+    </>
+  )
+}
 
 export const Default = {
   args: {
@@ -50,6 +68,9 @@ export const Default = {
     title: 'What do you think?',
     description: 'Choose either of the options below.',
     options,
+    ws: {
+      send: () => {},
+    },
   },
 }
 
@@ -69,6 +90,7 @@ export const InMessageSpace = {
               format: 'question',
               data: {},
             }}
+            getProfileComponent={() => getProfileIconAndName(agent.name)}
           >
             <Story
               args={{
@@ -85,7 +107,7 @@ export const InMessageSpace = {
               <MessageCanvas
                 message={{
                   id: '2',
-                  sender: { name: 'Some User', id: 'gahjqj19' },
+                  sender: user,
                   timestamp: new Date().toISOString(),
                   conversationId: '1',
                   format: 'text',
@@ -93,6 +115,7 @@ export const InMessageSpace = {
                     text: selectedOption,
                   },
                 }}
+                getProfileComponent={() => getProfileIconAndName(user.name)}
               >
                 <Text text={selectedOption} />
               </MessageCanvas>


### PR DESCRIPTION
## Changes
- add getProfileComponent to "In Message Space" story
- avoid `Uncaught TypeError: Cannot read properties of undefined (reading 'send')` 

## Screenshots
### Before
<img width="633" alt="Screenshot 2024-06-16 at 8 20 31 AM" src="https://github.com/rustic-ai/ui-components/assets/111031789/068bff90-958f-41a8-b69e-cd74744835d7">

![before](https://github.com/rustic-ai/ui-components/assets/111031789/9ee6aa2a-82ac-4882-9f13-4a9b3dd00e23)

### After
<img width="633" alt="Screenshot 2024-06-16 at 8 27 36 AM" src="https://github.com/rustic-ai/ui-components/assets/111031789/2b5bf4ea-6306-4f02-b8a3-3a90a3c2006d">

![after](https://github.com/rustic-ai/ui-components/assets/111031789/9e564b60-019d-42b2-af46-5e44c83dd602)
