### PR TITLE
fix(textInput): resolve console error

### DIFF
--- a/src/components/input/baseInput/baseInput.tsx
+++ b/src/components/input/baseInput/baseInput.tsx
@@ -202,16 +202,18 @@ function BaseInputElement(
       <Box className="rustic-input-actions">
         {props.children}
         <Tooltip title="Send">
-          <IconButton
-            data-cy="send-button"
-            aria-label="send message"
-            onClick={handleSendMessage}
-            disabled={isSendDisabled}
-            color="primary"
-            className="rustic-send-button"
-          >
-            <Icon name="send" />
-          </IconButton>
+          <span>
+            <IconButton
+              data-cy="send-button"
+              aria-label="send message"
+              onClick={handleSendMessage}
+              disabled={isSendDisabled}
+              color="primary"
+              className="rustic-send-button"
+            >
+              <Icon name="send" />
+            </IconButton>
+          </span>
         </Tooltip>
       </Box>
     </Box>


### PR DESCRIPTION
## Change:
- Resolve tooltip error in TextInput

## Before
<img width="478" alt="Screenshot 2024-06-20 at 4 46 07 PM" src="https://github.com/rustic-ai/ui-components/assets/103023797/6a4360cc-e988-493a-8dd1-f04455f73ce5">

## After
<img width="480" alt="Screenshot 2024-06-20 at 4 45 57 PM" src="https://github.com/rustic-ai/ui-components/assets/103023797/5d5f0368-b684-4167-952f-036ecbf899f0">
