### PR TITLE
fix(popoverMenu): resolve console error

### DIFF
--- a/src/components/menu/popoverMenu.tsx
+++ b/src/components/menu/popoverMenu.tsx
@@ -154,6 +154,7 @@ export default function PopoverMenu(props: PopoverMenuProps) {
     }
   }
 
+  const anchorElProp = isMobileView ? {} : { anchorEl: menuButtonRef.current }
   return (
     <>
       {renderButton()}
@@ -161,7 +162,7 @@ export default function PopoverMenu(props: PopoverMenuProps) {
       <PopoverMenuElement
         open={isMenuOpen}
         onClose={() => setIsMenuOpen(false)}
-        anchorEl={menuButtonRef.current}
+        {...anchorElProp}
         anchor="bottom"
         className="rustic-popover-menu"
         sx={{


### PR DESCRIPTION
## Change
- Resolve the console error for `PopoverMenu` component. (Popover menu is a menu on desktop version and a drawer on mobile version. Only menu has the `anchorEl` property so I avoid assigning `anchorEl` to drawer. Reference: https://mui.com/material-ui/api/drawer/)

## Screenshots
### Before
<img width="1491" alt="Screenshot 2024-06-21 at 5 06 03 PM" src="https://github.com/rustic-ai/ui-components/assets/103023797/9daf21ce-28f1-4c98-8f37-d410d9ec16d1">

### After
<img width="1489" alt="Screenshot 2024-06-21 at 5 05 48 PM" src="https://github.com/rustic-ai/ui-components/assets/103023797/a0c6f960-1506-49f1-b73d-a62c7ec6cc07">
