### PR TITLE
fix(perspectiveViz): improve styling

### DIFF
--- a/src/components/visualization/perspectiveViz/perspectiveViz.css
+++ b/src/components/visualization/perspectiveViz/perspectiveViz.css
@@ -1,10 +1,15 @@
 .rustic-perspective-viz {
   width: 100%;
   height: 100%;
-  min-width: 300px;
+  min-width: 250px;
 }
 
 .rustic-perspective-viz perspective-viewer {
   flex: 1;
   min-height: 200px;
+}
+
+/* Hide scroll button */
+perspective-viewer-datagrid-toolbar {
+  display: none;
 }

--- a/src/components/visualization/perspectiveViz/perspectiveViz.stories.tsx
+++ b/src/components/visualization/perspectiveViz/perspectiveViz.stories.tsx
@@ -10,6 +10,11 @@ const meta: Meta<React.ComponentProps<typeof PerspectiveViz>> = {
   tags: ['autodocs'],
   parameters: {
     layout: 'centered',
+    docs: {
+      argTypes: {
+        sort: 'requiredFirst',
+      },
+    },
   },
 }
 

--- a/src/components/visualization/perspectiveViz/perspectiveViz.tsx
+++ b/src/components/visualization/perspectiveViz/perspectiveViz.tsx
@@ -51,6 +51,55 @@ export function transformTableData(
   })
 }
 
+const perspectiveVizAdditionalStyles = `
+/* General Button Styles */
+button, .button:hover, #editor-container, .editable {
+  border-radius: 16px !important;
+}
+
+/* Hide border for aggregate Selector */
+.aggregate-selector:hover {
+  border: none !important;
+}
+
+/* Input and Select Elements */
+input, select, .noselect, #add-expression, .dropdown-width-container, 
+.pivot-column-border, .pivot-column, .column-selector-column-border {
+  border-radius: 8px !important;
+}
+
+/* Change background color */
+#settings_panel, #column_settings_sidebar {
+  background: white;
+}
+
+/* Expression Edit Button */
+.expression-edit-button {
+  display: none;
+}
+
+/* Add padding to expression input */
+#editor-container, .editable {
+  padding: 8px !important;
+}
+
+/* Change Button Font Size */
+.button select, .button {
+  font-size: 12px !important;
+}
+
+/* Enable Scrolling */
+#plugin_selector_container.open, #status_bar, #menu-bar, #app_panel {
+  overflow: scroll !important;
+}
+
+/* Hide unused buttons */
+#debug_open_button.sidebar_close_button, .reset-default-style-disabled, 
+.expression-edit-button, #theme, #status, #status_bar .input-sizer {
+  display: none !important;
+}
+`
+
 /**
 The PerspectiveViz component is designed to efficiently display and process large datasets, supporting interactive features such as filtering, sorting, and aggregating data for enhanced analysis and visualization. It integrates with the [Perspective library](https://perspective.finos.org/) to render data in various formats, including datagrids(pivot tables) and charts.
 
@@ -129,11 +178,7 @@ function PerspectiveViz(props: TableData) {
               })
               if (viewer.shadowRoot) {
                 const sheet = new CSSStyleSheet()
-                sheet.replaceSync(
-                  '#settings_panel { background: none}' +
-                    '#plugin_selector_container.open { overflow: scroll!important;}' +
-                    '#debug_open_button.sidebar_close_button { display: none; }'
-                )
+                sheet.replaceSync(perspectiveVizAdditionalStyles)
                 viewer.shadowRoot.adoptedStyleSheets.push(sheet)
               }
             })


### PR DESCRIPTION
## Changes
- Improve the styling of perspectiveViz component (Some elements are unnecessary and are therefore hidden. Couldn't change the styling of popover menu because it's from html select element)
- min-width is reduced slightly to fit into iphone 6 screen
- Sort props in storybook

### Before
<img width="872" alt="Screenshot 2024-06-22 at 4 25 18 PM" src="https://github.com/rustic-ai/ui-components/assets/103023797/87b988ce-bc6d-45f3-ae5c-dc6ddadbe016">
<img width="872" alt="Screenshot 2024-06-22 at 4 25 35 PM" src="https://github.com/rustic-ai/ui-components/assets/103023797/99597897-5fbe-474c-a60d-59b3e40aa083">
<img width="864" alt="Screenshot 2024-06-22 at 4 26 03 PM" src="https://github.com/rustic-ai/ui-components/assets/103023797/cec15001-c549-468a-ae66-c575a5dd318f">

### After
<img width="873" alt="Screenshot 2024-06-22 at 4 23 53 PM" src="https://github.com/rustic-ai/ui-components/assets/103023797/2b14630e-2e9e-4b11-9a34-ffdfcabf2dab">
<img width="890" alt="Screenshot 2024-06-22 at 4 24 22 PM" src="https://github.com/rustic-ai/ui-components/assets/103023797/36791a14-140c-4bf5-81d2-fcb29631f6f4">
<img width="866" alt="Screenshot 2024-06-22 at 4 24 49 PM" src="https://github.com/rustic-ai/ui-components/assets/103023797/8d321022-5491-4d1e-a84b-5c3d2a1f559a">
