### PR TITLE
fix(pdfViewer): resolve console errors

### DIFF
--- a/src/components/pdfViewer/controlButton/controlButton.tsx
+++ b/src/components/pdfViewer/controlButton/controlButton.tsx
@@ -26,14 +26,16 @@ function ViewerControlButton(props: ViewerControlButtonProps) {
 
   return (
     <Tooltip title={control.label}>
-      <IconButton
-        onClick={props.onClick}
-        className={props.className}
-        disabled={props.isDisabled}
-        data-cy={`${dataCyPrefix}-button`}
-      >
-        <Icon name={control.symbol} />
-      </IconButton>
+      <span>
+        <IconButton
+          onClick={props.onClick}
+          className={props.className}
+          disabled={props.isDisabled}
+          data-cy={`${dataCyPrefix}-button`}
+        >
+          <Icon name={control.symbol} />
+        </IconButton>
+      </span>
     </Tooltip>
   )
 }


### PR DESCRIPTION
## Changes
- Fix flaky test by handle page.render promise (Can't verify if it's still flaky, but I've tried running the tests locally several times and the tests didn't fail)
- Fix tooltip console error
- Fix console error related to TextField. It shouldn't be placed within Typography

## Screenshot
### Before 
<img width="549" alt="Screenshot 2024-06-24 at 11 39 16 PM" src="https://github.com/rustic-ai/ui-components/assets/103023797/3ae485af-d028-4865-8445-70503273e710">
<img width="542" alt="Screenshot 2024-06-24 at 11 39 02 PM" src="https://github.com/rustic-ai/ui-components/assets/103023797/1f86b6e6-4bf2-4a97-9158-1f2de2be08ce">

### After
<img width="1417" alt="Screenshot 2024-06-24 at 11 38 26 PM" src="https://github.com/rustic-ai/ui-components/assets/103023797/39c89097-51d2-496a-b332-3fa3186a8bbc">
