### PR TITLE
docs(messageSpace): fix agent icon not displaying

### DIFF
--- a/src/components/messageSpace/messageSpace.stories.tsx
+++ b/src/components/messageSpace/messageSpace.stories.tsx
@@ -46,7 +46,7 @@ const meta: Meta<React.ComponentProps<typeof MessageSpace>> = {
 export default meta
 
 function getProfileIcon(message: ThreadableMessage) {
-  if (message.sender.name?.includes('agent')) {
+  if (message.sender.name?.toLowerCase().includes('agent')) {
     return <Icon name="smart_toy" />
   } else {
     return <Icon name="account_circle" />


### PR DESCRIPTION
## Changes
- fix agent icon not displaying

## Screenshots
### Before
<img width="1198" alt="Screenshot 2024-06-26 at 3 48 29 PM" src="https://github.com/rustic-ai/ui-components/assets/111031789/2004c502-ace2-4979-878f-51b723630ef8">

### After
<img width="1198" alt="Screenshot 2024-06-26 at 3 48 09 PM" src="https://github.com/rustic-ai/ui-components/assets/111031789/d74fb726-a620-47f1-87c7-9274869e5b08">
