### PR TITLE
docs: sort argTypes table by required

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -83,6 +83,9 @@ const preview = {
           <Stories />
         </>
       ),
+      argTypes: {
+        sort: 'requiredFirst',
+      },
     },
   },
 }

--- a/src/components/input/multimodal/multimodalInput/multimodalInput.stories.tsx
+++ b/src/components/input/multimodal/multimodalInput/multimodalInput.stories.tsx
@@ -12,11 +12,6 @@ const multiModalInputMeta: Meta<React.ComponentProps<typeof MultimodalInput>> =
     component: MultimodalInput,
     tags: ['autodocs'],
     parameters: {
-      docs: {
-        argTypes: {
-          sort: 'requiredFirst',
-        },
-      },
       layout: 'centered',
       mockData: [
         {

--- a/src/components/input/textInput/textInput.stories.tsx
+++ b/src/components/input/textInput/textInput.stories.tsx
@@ -25,7 +25,6 @@ const meta: Meta<React.FC<InputProps>> = {
       },
       argTypes: {
         exclude: ['send', 'isSendEnabled'],
-        sort: 'requiredFirst',
       },
       source: {
         transform: (code: string) => {

--- a/src/components/visualization/perspectiveViz/perspectiveViz.stories.tsx
+++ b/src/components/visualization/perspectiveViz/perspectiveViz.stories.tsx
@@ -10,11 +10,6 @@ const meta: Meta<React.ComponentProps<typeof PerspectiveViz>> = {
   tags: ['autodocs'],
   parameters: {
     layout: 'centered',
-    docs: {
-      argTypes: {
-        sort: 'requiredFirst',
-      },
-    },
   },
 }
 


### PR DESCRIPTION
## Changes
- sort argTypes table by required props globally

## Screenshots

### Before

#### Sound
<img width="844" alt="Screenshot 2024-06-27 at 4 19 09 PM" src="https://github.com/rustic-ai/ui-components/assets/111031789/85d4fd56-1047-43fb-8250-99778d56d00b">

#### Calendar
<img width="844" alt="Screenshot 2024-06-27 at 4 19 20 PM" src="https://github.com/rustic-ai/ui-components/assets/111031789/27e759f9-83a2-4c4a-bf87-6ebfae801f1f">

### After

#### Sound
<img width="844" alt="Screenshot 2024-06-27 at 4 19 45 PM" src="https://github.com/rustic-ai/ui-components/assets/111031789/8dc90465-4eda-4b17-b680-5b7ffbe33a7d">

#### Calendar
<img width="844" alt="Screenshot 2024-06-27 at 4 19 56 PM" src="https://github.com/rustic-ai/ui-components/assets/111031789/823c6e82-b6b3-488a-8db1-6e4581e48308">
