### PR TITLE
docs(rechartsTimeSeries): use argTypes table to display prop fields

### DIFF
--- a/src/components/visualization/chart/rechartsTimeSeries.stories.tsx
+++ b/src/components/visualization/chart/rechartsTimeSeries.stories.tsx
@@ -7,13 +7,28 @@ export default {
   tags: ['autodocs'],
   argTypes: {
     timeSeries: {
-      control: 'array',
-      description:
-        'Data to be displayed in the time series chart. The first field is used as the x-axis field. We currently support formatting timestamps in seconds and milliseconds. Other data types will be displayed as given. \n<pre>```interface TimeSeriesData {\n  timestamp: number\n  [key: string]: number\n}```</pre>',
+      table: {
+        type: {
+          summary: 'Array of TimeSeriesData',
+          detail:
+            'Each TimeSeriesData object has the following fields:\n' +
+            '  timestamp: Timestamp in milliseconds.\n ' +
+            ' [key: string]: Numbered data point.',
+        },
+      },
     },
     chartContainerMargin: {
-      description:
-        'Margin of chart container in pixel. For example, adding left margin could show larger numbers properly.\n<pre>```interface Margin {\n  top?: number\n  right?: number\n  bottom?: number\n  left?: number\n}```</pre>',
+      table: {
+        type: {
+          summary: 'Margin',
+          detail:
+            'Margin has the following optional fields:\n' +
+            '  top: Number of pixels to add to the top of the chart container.\n' +
+            '  right: Number of pixels to add to the right of the chart container.\n' +
+            '  bottom: Number of pixels to add to the bottom of the chart container.\n' +
+            '  left: Number of pixels to add to the left of the chart container.',
+        },
+      },
     },
   },
   parameters: {

--- a/src/components/visualization/chart/rechartsTimeSeries.tsx
+++ b/src/components/visualization/chart/rechartsTimeSeries.tsx
@@ -40,7 +40,7 @@ export interface Margin {
 }
 
 export interface RechartsTimeSeriesProps {
-  /** Data to be displayed in the time series chart. The first field is used as the x-axis field. We currently support formatting epoch timestamps and ISO date strings. Other data types will be displayed as given. */
+  /** Data to be displayed in the time series chart. The first field is used as the x-axis field. We currently support formatting timestamps in milliseconds. Other data types will be displayed as given. */
   timeSeries: TimeSeriesData[]
   /** An array containing a predefined set of Hex color codes or string colors (e.g. 'blue'). The colors will be applied to the keys of the data object in order. */
   chartColors: string[]
@@ -80,7 +80,7 @@ export interface RechartsTimeSeriesProps {
   yAxisTickFormatter?: (value: number) => string
   /** Pass a function to format tooltip content. */
   tooltipFormatter?: (value: number, name: string) => [string, string]
-  /** Margin of chart container in pixel. For example, adding left margin could show larger numbers properly. */
+  /** Margin of chart container in pixels. For example, adding left margin could show larger numbered labels properly. */
   chartContainerMargin?: Margin
 }
 


### PR DESCRIPTION
## Changes
- use argTypes table to display prop fields
- remove console error

## Screenshots
### Before
<img width="1191" alt="Screenshot 2024-06-29 at 8 29 44 AM" src="https://github.com/rustic-ai/ui-components/assets/111031789/c07f2bc5-4ff9-4717-adf1-53f767556b6c">

### After
<img width="1191" alt="Screenshot 2024-06-29 at 8 57 37 AM" src="https://github.com/rustic-ai/ui-components/assets/111031789/4f74dea4-1669-4b40-b1ef-260715bbe1e0">
<img width="725" alt="Screenshot 2024-06-29 at 9 02 24 AM" src="https://github.com/rustic-ai/ui-components/assets/111031789/8cf3ef4d-6917-42f2-ab2f-2a90ef081923">
<img width="725" alt="Screenshot 2024-06-29 at 9 02 17 AM" src="https://github.com/rustic-ai/ui-components/assets/111031789/06e7ea1c-8006-47dd-b639-67b157039326">