### PR TITLE
docs: show sender object and update quickstart doc

### DIFF
--- a/docs/quickStart.mdx
+++ b/docs/quickStart.mdx
@@ -57,10 +57,31 @@ Follow these steps to quickly integrate Rustic UI Components into your applicati
        // Sample data for messages. Please make sure your message data uses props we defined for each message format.
        const messages = [/* Your message data array */];
 
+       // Sender data of user viewing the messages.
+       const sender = {
+            name: 'John Doe',
+            id: '123'
+       }
+
+       // Sample WebSocket connection object.
+       const ws = {
+            send: (message: Message) => {
+                /* Your custom logic */
+            },
+            close: () => {
+            /* Your custom logic */
+            },
+            reconnect: () => {
+            /* Your custom logic */
+            },
+       }
+
        return (
            <>
                <MessageSpace
                    messages={messages}
+                   sender={sender}
+                   ws={ws}
                    supportedElements={{
                    text: Text,
                    streamingText: StreamingText,

--- a/src/components/input/textInput/textInput.stories.tsx
+++ b/src/components/input/textInput/textInput.stories.tsx
@@ -69,8 +69,8 @@ meta.argTypes = {
       type: {
         summary: 'Sender',
         detail:
-          'id: string representing sender id\n' +
-          'name: Optional string of sender name',
+          'id: String representing sender id.\n' +
+          'name: Optional string of sender name.',
       },
     },
   },

--- a/src/components/messageSpace/messageSpace.stories.tsx
+++ b/src/components/messageSpace/messageSpace.stories.tsx
@@ -73,7 +73,7 @@ meta.argTypes = {
           'ThreadableMessage extends the Message interface which has the following fields:\n' +
           '  id: A string representing the unique identifier of the message.\n' +
           '  timestamp: A string representing the timestamp of the message.\n' +
-          '  sender: An object representing the sender of the message.\n' +
+          '  sender: An object representing the sender of the message. Refer to the `sender` prop.\n' +
           '  conversationId: A string representing the identifier of the conversation to which the message belongs.\n' +
           '  format: A string representing the format of the message.\n' +
           '  data: An object of type MessageData, which can contain any key-value pairs.\n' +
@@ -94,6 +94,16 @@ meta.argTypes = {
         summary: 'WebSocketClient',
         detail:
           'send: (message: Message) => void\nclose: () => void\nreconnect: () => void\n',
+      },
+    },
+  },
+  sender: {
+    table: {
+      type: {
+        summary: 'Sender',
+        detail:
+          'id: String representing sender id.\n' +
+          'name: Optional string of sender name.',
       },
     },
   },

--- a/src/components/question/question.stories.tsx
+++ b/src/components/question/question.stories.tsx
@@ -36,6 +36,16 @@ meta.argTypes = {
       },
     },
   },
+  sender: {
+    table: {
+      type: {
+        summary: 'Sender',
+        detail:
+          'id: String representing sender id.\n' +
+          'name: Optional string of sender name.',
+      },
+    },
+  },
 }
 
 export default meta


### PR DESCRIPTION
## Changes
- show sender object in `MessageSpace` and `Question` components
- update code snippet in Quick Start doc

## Screenshots
### Before
<img width="761" alt="Screenshot 2024-06-30 at 10 11 20 AM" src="https://github.com/rustic-ai/ui-components/assets/111031789/20ff743c-1d5d-404b-80b9-24d3c7d7b54c">
<img width="761" alt="Screenshot 2024-06-30 at 10 12 35 AM" src="https://github.com/rustic-ai/ui-components/assets/111031789/9ffe2a62-d88e-4628-9886-4f82fd38577f">

### After
<img width="761" alt="Screenshot 2024-06-30 at 10 10 56 AM" src="https://github.com/rustic-ai/ui-components/assets/111031789/3b99f127-7882-424a-89b8-7785668d35aa">
<img width="761" alt="Screenshot 2024-06-30 at 10 12 52 AM" src="https://github.com/rustic-ai/ui-components/assets/111031789/762c200c-8030-45cc-a74d-9431112f15fe">


