### PR TITLE
fix: tooltip position

### DIFF
--- a/src/components/input/baseInput/baseInput.tsx
+++ b/src/components/input/baseInput/baseInput.tsx
@@ -341,14 +341,13 @@ function BaseInputElement(
       <Box className="rustic-input-actions">
         {props.children}
         <Tooltip title="Send">
-          <span>
+          <span className="rustic-send-button">
             <IconButton
               data-cy="send-button"
               aria-label="send message"
               onClick={handleSendMessage}
               disabled={isSendDisabled}
               color="primary"
-              className="rustic-send-button"
             >
               <Icon name="send" />
             </IconButton>


### PR DESCRIPTION
## Change:
- Fix the tooltip position for send button in the MultimodalInput component

## Before
<img width="703" alt="Screenshot 2024-07-02 at 3 24 05 PM" src="https://github.com/rustic-ai/ui-components/assets/103023797/1029216b-c181-4081-993a-18166d341721">

## After
<img width="635" alt="Screenshot 2024-07-02 at 3 23 37 PM" src="https://github.com/rustic-ai/ui-components/assets/103023797/796e10af-07af-4fa2-8c3b-2b067ba1f024">
