### PR TITLE
fix(vegaliteViz): render spec title and description outside of VegaLite

### DIFF
--- a/src/components/visualization/vegaLiteViz/vegaLiteViz.stories.tsx
+++ b/src/components/visualization/vegaLiteViz/vegaLiteViz.stories.tsx
@@ -113,7 +113,7 @@ export const WithTitleAndDescription = {
     spec: {
       $schema: 'https://vega.github.io/schema/vega-lite/v5.json',
       width: 'container',
-      height: 'container',
+      height: '200',
       title: 'Number of Orders by Product',
       description:
         'This chart shows the number of orders by product in the last month.',
@@ -145,7 +145,6 @@ export const WithTitleAndDescription = {
     description:
       "The chart below illustrates the distribution of orders across different products in the last month for X Company. Each product's order count is displayed in thousands, providing a clear comparison of product performance.",
   },
-  decorators,
 }
 
 export const InvalidChart = {
@@ -388,7 +387,6 @@ export const Map = {
       ],
     },
   },
-  // decorators,
 }
 
 export const GlobeVisualization = {

--- a/src/components/visualization/vegaLiteViz/vegaLiteViz.tsx
+++ b/src/components/visualization/vegaLiteViz/vegaLiteViz.tsx
@@ -74,8 +74,9 @@ function VegaLiteViz(props: VegaLiteData) {
       if (!props.options?.config?.font) {
         options.config.font = defaultFont
       }
-
-      VegaEmbed(chartRef.current, props.spec, options)
+      const specToRender = { ...props.spec }
+      delete specToRender.title
+      VegaEmbed(chartRef.current, specToRender, options)
         .then((result) => {
           const opts = result.embedOptions
           const fileName =
@@ -125,12 +126,18 @@ function VegaLiteViz(props: VegaLiteData) {
           <PopoverMenu menuItems={menuItems} ariaLabel="Download options" />
         </Box>
 
-        {props.title && (
-          <Typography variant="subtitle2">{props.title}</Typography>
-        )}
+        {props.title && <Typography variant="h6">{props.title}</Typography>}
         {props.description && (
-          <Typography variant="caption">{props.description}</Typography>
+          <Typography variant="body1">{props.description}</Typography>
         )}
+        <Box textAlign="center" mt={1}>
+          {typeof props.spec.title === 'string' && (
+            <Typography variant="subtitle2">{props.spec.title}</Typography>
+          )}
+          {props.spec.description && (
+            <Typography variant="caption">{props.spec.description}</Typography>
+          )}
+        </Box>
         <div ref={chartRef} className="rustic-vega-lite" data-cy="vega-lite" />
       </Stack>
     )


### PR DESCRIPTION
## Change
- VegaLite does not support word wrap for titles and uses the description solely for commenting purposes. To address the word wrap limitation, both the title and description are now directly rendered outside of VegaLite.

## Before
<img width="306" alt="Screenshot 2024-07-03 at 1 58 39 PM" src="https://github.com/rustic-ai/ui-components/assets/103023797/e3ed40ff-b48a-4801-b7d3-a3e98b152713">

<img width="742" alt="Screenshot 2024-07-03 at 1 58 11 PM" src="https://github.com/rustic-ai/ui-components/assets/103023797/1553a859-9647-4a8a-92f2-9b50b12f3e74">
<img width="308" alt="Screenshot 2024-07-03 at 1 59 11 PM" src="https://github.com/rustic-ai/ui-components/assets/103023797/a0cee8c6-21f2-448a-8c17-810eec40dead">

## After
<img width="305" alt="Screenshot 2024-07-03 at 1 57 45 PM" src="https://github.com/rustic-ai/ui-components/assets/103023797/3aeececf-8078-47ca-bcd4-3c92a8442bd4">

<img width="960" alt="Screenshot 2024-07-03 at 1 56 40 PM" src="https://github.com/rustic-ai/ui-components/assets/103023797/1668e55f-8cc6-4ea2-a8e0-b14e7ed586ac">
<img width="341" alt="Screenshot 2024-07-03 at 1 57 09 PM" src="https://github.com/rustic-ai/ui-components/assets/103023797/a5716763-a638-4496-a93d-604bb04cd5cc">
