### PR TITLE
fix(multipart): add pdfViewer

### DIFF
--- a/src/components/filePreview/filePreview.css
+++ b/src/components/filePreview/filePreview.css
@@ -8,11 +8,7 @@
   height: 56px;
 }
 
-.rustic-cursor-pointer {
-  cursor: pointer;
-}
-
-.rustic-pdf-viewer-modal {
+.rustic-file-preview-modal {
   width: 90vw;
   height: 90vh;
   display: flex;
@@ -20,12 +16,12 @@
   justify-self: center;
 }
 
-.rustic-pdf-viewer-modal .rustic-pdf-viewer-container {
+.rustic-file-preview-modal .rustic-modal-content {
   position: relative;
   width: 100%;
 }
 
-.rustic-pdf-viewer-container .rustic-close-button {
+.rustic-modal-content .rustic-close-button {
   position: absolute;
   top: 16px;
   right: 16px;

--- a/src/components/filePreview/filePreview.css
+++ b/src/components/filePreview/filePreview.css
@@ -7,3 +7,26 @@
   width: 220px;
   height: 56px;
 }
+
+.rustic-cursor-pointer {
+  cursor: pointer;
+}
+
+.rustic-pdf-viewer-modal {
+  width: 90vw;
+  height: 90vh;
+  display: flex;
+  align-self: center;
+  justify-self: center;
+}
+
+.rustic-pdf-viewer-modal .rustic-pdf-viewer-container {
+  position: relative;
+  width: 100%;
+}
+
+.rustic-pdf-viewer-container .rustic-close-button {
+  position: absolute;
+  top: 16px;
+  right: 16px;
+}

--- a/src/components/filePreview/filePreview.tsx
+++ b/src/components/filePreview/filePreview.tsx
@@ -16,6 +16,7 @@ import type { FileData } from '../types'
 
 export interface FilePreviewProps {
   file: FileData
+  supportedViewers?: { [key: string]: React.ComponentType<{ url: string }> }
 }
 
 const supportedViewers: {
@@ -41,16 +42,15 @@ export default function FilePreview(
     setIsModalOpen(false)
   }
 
-  function getFileExtension(url: string): string {
+  function getFileType(url: string): string {
     const splittedUrl = url.split('.')
     const extension = splittedUrl[splittedUrl.length - 1].toLowerCase()
     return extension
   }
 
-  const fileExtension = props.file.url && getFileExtension(props.file.url)
-  const ModalContentComponent = fileExtension
-    ? supportedViewers[fileExtension]
-    : null
+  const fileType = props.file.url && getFileType(props.file.url)
+  const ModalContentComponent =
+    fileType && props.supportedViewers ? props.supportedViewers[fileType] : null
   const hasModalContent = !!ModalContentComponent
 
   return (
@@ -90,4 +90,8 @@ export default function FilePreview(
       )}
     </>
   )
+}
+
+FilePreview.defaultProps = {
+  supportedViewers: supportedViewers,
 }

--- a/src/components/filePreview/filePreview.tsx
+++ b/src/components/filePreview/filePreview.tsx
@@ -1,11 +1,16 @@
 import './filePreview.css'
 
 import Card from '@mui/material/Card'
+import IconButton from '@mui/material/IconButton'
+import Modal from '@mui/material/Modal'
 import { useTheme } from '@mui/material/styles'
+import Tooltip from '@mui/material/Tooltip'
 import Typography from '@mui/material/Typography'
-import React from 'react'
+import React, { useState } from 'react'
 
 import { shortenString } from '../helper'
+import Icon from '../icon/icon'
+import PDFViewer from '../pdfViewer/pdfViewer'
 import type { FileData } from '../types'
 
 export interface FilePreviewProps {
@@ -17,17 +22,54 @@ export default function FilePreview(
 ) {
   const theme = useTheme()
   const maximumFileNameLength = 15
+
+  const [isModalOpen, setIsModalOpen] = useState(false)
+
+  function handleFileClick() {
+    setIsModalOpen(true)
+  }
+
+  function handleCloseModal() {
+    setIsModalOpen(false)
+  }
+
+  const isPdfFile =
+    props.file.url && props.file.url.toLowerCase().endsWith('.pdf')
+
   return (
-    <Card
-      className="rustic-file-preview"
-      data-cy="file-preview"
-      variant="outlined"
-      sx={{ boxShadow: theme.shadows[1] }}
-    >
-      <Typography variant="subtitle2" data-cy="file-name">
-        {shortenString(props.file.name, maximumFileNameLength)}
-      </Typography>
-      {props.children}
-    </Card>
+    <>
+      <Card
+        className={`rustic-file-preview${isPdfFile ? ' rustic-cursor-pointer' : ''}`}
+        data-cy="file-preview"
+        variant="outlined"
+        sx={{ boxShadow: theme.shadows[1] }}
+        onClick={handleFileClick}
+      >
+        <Typography variant="subtitle2" data-cy="file-name">
+          {shortenString(props.file.name, maximumFileNameLength)}
+        </Typography>
+        <div onClick={(e) => e.stopPropagation()}>{props.children}</div>
+      </Card>
+      {isPdfFile && (
+        <Modal
+          open={isModalOpen}
+          onClose={handleCloseModal}
+          className="rustic-pdf-viewer-modal"
+        >
+          <div className="rustic-pdf-viewer-container">
+            <Tooltip title="Close">
+              <IconButton
+                onClick={handleCloseModal}
+                className="rustic-close-button"
+                data-cy="pdf-viewer-close-button"
+              >
+                <Icon name="close" />
+              </IconButton>
+            </Tooltip>
+            {props.file.url && <PDFViewer url={props.file.url} />}
+          </div>
+        </Modal>
+      )}
+    </>
   )
 }

--- a/src/components/multipart/multipart.cy.tsx
+++ b/src/components/multipart/multipart.cy.tsx
@@ -1,7 +1,10 @@
 import React from 'react'
 
 import { supportedViewports } from '../../../cypress/support/variables'
+import { setPdfWorkerSrc } from '../pdfViewer/pdfViewer'
 import Multipart from './multipart'
+
+setPdfWorkerSrc('/files/pdf.worker.mjs')
 
 describe('Multipart Component', () => {
   const props = {
@@ -45,6 +48,18 @@ describe('Multipart Component', () => {
       )
 
       cy.get('[data-cy=download-button]').should('be.visible')
+    })
+    it(`can open and close the pdfViewer for pdf file on ${viewport} screen`, () => {
+      cy.mount(
+        <Multipart
+          files={[{ name: 'pdfExample.pdf', url: '/files/pdfExample.pdf' }]}
+        />
+      )
+
+      cy.get('[data-cy=file-name]').click()
+      cy.get('[data-cy=pdf-canvas]').should('be.visible')
+      cy.get('[data-cy=pdf-viewer-close-button]').click()
+      cy.get('[data-cy=pdf-canvas]').should('not.exist')
     })
   })
 })

--- a/src/components/multipart/multipart.cy.tsx
+++ b/src/components/multipart/multipart.cy.tsx
@@ -11,7 +11,7 @@ describe('Multipart Component', () => {
     text: 'This is a test message',
     files: [{ name: 'image.jpg' }, { name: 'document.pdf' }],
   }
-
+  const fileName = '[data-cy=file-name]'
   const filePreview = `[data-cy=file-preview]`
   supportedViewports.forEach((viewport) => {
     it(`renders text and file previews correctly on ${viewport} screen`, () => {
@@ -23,7 +23,7 @@ describe('Multipart Component', () => {
 
       props.files.forEach((file, index) => {
         cy.get(`${filePreview}:eq(${index})`).within(() => {
-          cy.get('[data-cy=file-name]').should(
+          cy.get(fileName).should(
             'contain',
             file.name.substring(0, maximumFileNameLength)
           )
@@ -56,9 +56,9 @@ describe('Multipart Component', () => {
         />
       )
 
-      cy.get('[data-cy=file-name]').click()
+      cy.get(fileName).click()
       cy.get('[data-cy=pdf-canvas]').should('be.visible')
-      cy.get('[data-cy=pdf-viewer-close-button]').click()
+      cy.get('[data-cy=viewer-close-button]').click()
       cy.get('[data-cy=pdf-canvas]').should('not.exist')
     })
   })

--- a/src/components/multipart/multipart.stories.tsx
+++ b/src/components/multipart/multipart.stories.tsx
@@ -54,8 +54,8 @@ export const FileWithURL = {
   args: {
     files: [
       {
-        name: 'image.png',
-        url: 'images/image-component-example.png',
+        name: 'pdfExample.pdf',
+        url: 'files/pdfExample.pdf',
       },
     ],
   },

--- a/src/components/types.ts
+++ b/src/components/types.ts
@@ -261,6 +261,13 @@ export interface MultipartFormat extends DataFormat {
   files: FileData[]
   /** Text content sent along with the files. */
   text?: string
+  /**
+   * An object mapping file extensions to their respective viewer components.
+   * Each key represents a file type (e.g., 'pdf', 'jpg'), and the corresponding value is a React component
+   * that takes a `url` prop and renders the appropriate viewer for that file type. This prop is used to decide
+   * which viewer component should be used to open and display the file within the modal.
+   */
+  supportedViewers?: { [key: string]: React.ComponentType<{ url: string }> }
 }
 
 export type MultipartData = MultipartFormat & Updates<MultipartFormat>

--- a/src/index.css
+++ b/src/index.css
@@ -23,3 +23,7 @@ code {
   gap: 8px;
   flex-wrap: wrap;
 }
+
+.rustic-cursor-pointer {
+  cursor: pointer;
+}


### PR DESCRIPTION
## Change
- Support pdfViewer for pdf files. PdfViewer will not be opened for other file types. 
- Close button is added
- Update test and storybook

## Screenshot

### Original pdfViewer
<img width="1288" alt="Screenshot 2024-07-04 at 5 18 47 PM" src="https://github.com/rustic-ai/ui-components/assets/103023797/297d7c43-bcb5-416f-8c60-0f9f2b1a1ff8">

### pdfViewer in a modal with close button
<img width="1287" alt="Screenshot 2024-07-04 at 5 18 28 PM" src="https://github.com/rustic-ai/ui-components/assets/103023797/67d8d281-1f57-48fd-8566-16df0165f5c3">

## Video
https://github.com/rustic-ai/ui-components/assets/103023797/dc3bdd22-0f29-4a79-bd24-5c021df8f20a

