### PR TITLE
docs(messageSpace): fix formatting

### DIFF
--- a/src/components/messageSpace/messageSpace.tsx
+++ b/src/components/messageSpace/messageSpace.tsx
@@ -37,8 +37,10 @@ function usePrevious(value: number) {
 }
 
 /**
- The `MessageSpace` component uses `MessageCanvas` and `ElementRenderer` to render a list of messages. It serves as a container for individual message items, each encapsulated within a `MessageCanvas` for consistent styling and layout. \n\n Note: For more information about the `getActionsComponent` and `getProfileComponent` fields, refer to the [MessageCanvas' docs](http://localhost:6006/?path=/docs/rustic-ui-message-canvas-message-canvas--docs).
- */
+ The `MessageSpace` component uses `MessageCanvas` and `ElementRenderer` to render a list of messages. It serves as a container for individual message items, each encapsulated within a `MessageCanvas` for consistent styling and layout.
+ 
+ Note: For more information about the `getActionsComponent` and `getProfileComponent` fields, refer to the [MessageCanvas' docs](http://localhost:6006/?path=/docs/rustic-ui-message-canvas-message-canvas--docs).
+*/
 
 export default function MessageSpace(props: MessageSpaceProps) {
   const scrollEndRef = useRef<HTMLDivElement>(null)


### PR DESCRIPTION
# Before
<img width="1037" alt="Screenshot 2024-07-05 at 10 18 54 AM" src="https://github.com/rustic-ai/ui-components/assets/8054014/6af54d15-bd87-42b2-920c-073cb5b4106e">

# After
<img width="1037" alt="Screenshot 2024-07-05 at 10 18 33 AM" src="https://github.com/rustic-ai/ui-components/assets/8054014/0518e191-e9ab-48d1-8ef4-7e89a0e5d9b1">
