### PR TITLE
fix(theme): use className to align center

### DIFF
--- a/src/components/messageSpace/messageSpace.tsx
+++ b/src/components/messageSpace/messageSpace.tsx
@@ -1,4 +1,5 @@
 import './messageSpace.css'
+import '../../index.css'
 
 import Chip from '@mui/material/Chip'
 import Box from '@mui/system/Box'
@@ -192,10 +193,10 @@ export default function MessageSpace(props: MessageSpaceProps) {
           size="medium"
           onClick={handleScrollDown}
           label={
-            <>
+            <div className="rustic-chip-label">
               {props.scrollDownLabel}
               <Icon name="arrow_downward" />
-            </>
+            </div>
           }
         />
       )}

--- a/src/index.css
+++ b/src/index.css
@@ -31,3 +31,9 @@ code {
 .rustic-align-self-center {
   align-self: center;
 }
+
+.rustic-chip-label {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}

--- a/src/rusticTheme.ts
+++ b/src/rusticTheme.ts
@@ -251,9 +251,6 @@ const chipGeneralStyle = {
   fontWeight: 700,
   '& .MuiChip-label': {
     padding: 0,
-    display: 'flex',
-    alignItems: 'center',
-    gap: '8px',
   },
 }
 const lightModePrimaryChipBasestyle = {


### PR DESCRIPTION
## Change
- use className to align text and icon in Chip label. I made this change so that the alignment won't be missed up if people don't use our theme

Question: 
### Before
<img width="172" alt="Screenshot 2024-07-19 at 4 11 51 PM" src="https://github.com/user-attachments/assets/d47d3980-1500-4636-af0b-032a1d460ac3">

### After
<img width="168" alt="Screenshot 2024-07-19 at 4 10 45 PM" src="https://github.com/user-attachments/assets/d3b4f3d8-4636-4335-9011-247c68f81a0a">
