### PR TITLE
fix: move supportedViewers out of MultipartData

### DIFF
--- a/src/components/multipart/multipart.tsx
+++ b/src/components/multipart/multipart.tsx
@@ -9,10 +9,10 @@ import React from 'react'
 import FilePreview from '../filePreview/filePreview'
 import Icon from '../icon/icon'
 import Text from '../text/text'
-import type { MultipartData } from '../types'
+import type { MultipartProps } from '../types'
 
 /** The `Multipart` component is a versatile message format designed to accommodate both textual content and file attachments within a single message interface. */
-export default function Multipart(props: MultipartData) {
+export default function Multipart(props: MultipartProps) {
   function renderFiles() {
     const files = props.files.map((file, index) => {
       return (

--- a/src/components/types.ts
+++ b/src/components/types.ts
@@ -236,6 +236,11 @@ export interface MultipartFormat extends DataFormat {
   files: FileData[]
   /** Text content sent along with the files. */
   text?: string
+}
+
+export type MultipartData = MultipartFormat & Updates<MultipartFormat>
+
+export interface MultipartProps extends MultipartData {
   /**
    * An object mapping file extensions to their respective viewer components.
    * Each key represents a file type (e.g., 'pdf', 'jpg'), and the corresponding value is a React component
@@ -244,8 +249,6 @@ export interface MultipartFormat extends DataFormat {
    */
   supportedViewers?: { [key: string]: React.ComponentType<{ url: string }> }
 }
-
-export type MultipartData = MultipartFormat & Updates<MultipartFormat>
 
 export interface BaseInputProps {
   /** Current user. */


### PR DESCRIPTION
## Changes
- Move supportedViewers out of MultipartData

## Screenshots (No UI changes)
### Before
<img width="662" alt="Screenshot 2024-07-25 at 1 20 52 PM" src="https://github.com/user-attachments/assets/24adceba-a48f-4c21-8d97-dad93f0984e0">

### After
<img width="662" alt="Screenshot 2024-07-25 at 1 20 52 PM" src="https://github.com/user-attachments/assets/a9d0ab21-6794-4375-b3ce-b4203a2e7811">
