### PR TITLE
fix: update message handling

### DIFF
--- a/src/components/elementRenderer/elementRenderer.cy.tsx
+++ b/src/components/elementRenderer/elementRenderer.cy.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import { v4 as getUUID } from 'uuid'
 
 import {
   supportedViewports,
@@ -89,17 +90,37 @@ describe('ElementRenderer', () => {
           messages={[
             {
               ...sampleMessage,
-              data: { text: 'Test' },
+              data: { text: 'This' },
               format: 'streamingText',
             },
             {
-              id: '2',
+              id: getUUID(),
               timestamp: '2020-01-02T00:00:00.000Z',
               sender: testUser,
               conversationId: 'lkd9vc',
               topic: 'default',
               threadId: '1',
-              data: { text: ' Text' },
+              data: { text: ' is' },
+              format: 'streamingText',
+            },
+            {
+              id: getUUID(),
+              timestamp: '2020-01-02T00:00:00.000Z',
+              sender: testUser,
+              conversationId: 'lkd9vc',
+              topic: 'default',
+              threadId: '1',
+              data: { text: ' streaming' },
+              format: 'streamingText',
+            },
+            {
+              id: getUUID(),
+              timestamp: '2020-01-02T00:00:00.000Z',
+              sender: testUser,
+              conversationId: 'lkd9vc',
+              topic: 'default',
+              threadId: '1',
+              data: { text: ' text.' },
               format: 'streamingText',
             },
           ]}
@@ -107,7 +128,7 @@ describe('ElementRenderer', () => {
           ws={mockWsClient}
         />
       )
-      cy.get('p').should('contain.text', 'Test Text')
+      cy.get('p').should('contain.text', 'This is streaming text.')
     })
 
     it(`renders a message for an unsupported format on ${viewport} screen`, () => {

--- a/src/components/elementRenderer/elementRenderer.cy.tsx
+++ b/src/components/elementRenderer/elementRenderer.cy.tsx
@@ -4,13 +4,14 @@ import {
   supportedViewports,
   testUser,
 } from '../../../cypress/support/variables'
-import { YoutubeVideo } from '..'
+import { StreamingText, YoutubeVideo } from '..'
 import Text from '../text/text'
 import ElementRenderer from './elementRenderer'
 
 const supportedElements = {
   text: Text,
   video: YoutubeVideo,
+  streamingText: StreamingText,
 }
 
 const sampleMessage = {
@@ -38,11 +39,13 @@ describe('ElementRenderer', () => {
       cy.viewport(viewport)
       cy.mount(
         <ElementRenderer
-          message={{
-            ...sampleMessage,
-            data: { text: 'Test Text' },
-            format: 'text',
-          }}
+          messages={[
+            {
+              ...sampleMessage,
+              data: { text: 'Test Text' },
+              format: 'text',
+            },
+          ]}
           {...commonProps}
           ws={mockWsClient}
         />
@@ -50,11 +53,13 @@ describe('ElementRenderer', () => {
       cy.get('p').should('contain.text', 'Test Text')
       cy.mount(
         <ElementRenderer
-          message={{
-            ...sampleMessage,
-            data: { youtubeVideoId: 'MtN1YnoL46Q' },
-            format: 'video',
-          }}
+          messages={[
+            {
+              ...sampleMessage,
+              data: { youtubeVideoId: 'MtN1YnoL46Q' },
+              format: 'video',
+            },
+          ]}
           {...commonProps}
           ws={mockWsClient}
         />
@@ -71,6 +76,40 @@ describe('ElementRenderer', () => {
       })
     })
 
+    it(`renders the original message and its update messages correctly on ${viewport} screen`, () => {
+      const mockWsClient = {
+        send: cy.stub(),
+        close: cy.stub(),
+        reconnect: cy.stub(),
+      }
+
+      cy.viewport(viewport)
+      cy.mount(
+        <ElementRenderer
+          messages={[
+            {
+              ...sampleMessage,
+              data: { text: 'Test' },
+              format: 'streamingText',
+            },
+            {
+              id: '2',
+              timestamp: '2020-01-02T00:00:00.000Z',
+              sender: testUser,
+              conversationId: 'lkd9vc',
+              topic: 'default',
+              threadId: '1',
+              data: { text: ' Text' },
+              format: 'streamingText',
+            },
+          ]}
+          {...commonProps}
+          ws={mockWsClient}
+        />
+      )
+      cy.get('p').should('contain.text', 'Test Text')
+    })
+
     it(`renders a message for an unsupported format on ${viewport} screen`, () => {
       const mockWsClient = {
         send: cy.stub(),
@@ -81,11 +120,13 @@ describe('ElementRenderer', () => {
       cy.viewport(viewport)
       cy.mount(
         <ElementRenderer
-          message={{
-            ...sampleMessage,
-            data: { text: 'Test Text' },
-            format: 'unsupported',
-          }}
+          messages={[
+            {
+              ...sampleMessage,
+              data: { text: 'Test Text' },
+              format: 'unsupported',
+            },
+          ]}
           {...commonProps}
           ws={mockWsClient}
         />

--- a/src/components/elementRenderer/elementRenderer.tsx
+++ b/src/components/elementRenderer/elementRenderer.tsx
@@ -1,39 +1,34 @@
 import Typography from '@mui/material/Typography'
 import React from 'react'
 
-import type {
-  ComponentMap,
-  Sender,
-  ThreadableMessage,
-  WebSocketClient,
-} from '../types'
+import type { ComponentMap, Message, Sender, WebSocketClient } from '../types'
 
 interface ElementRendererProps {
   sender: Sender
   ws: WebSocketClient
-  message: ThreadableMessage
+  messages: Message[]
   supportedElements: ComponentMap
 }
 
 const ElementRenderer = (props: ElementRendererProps) => {
-  const MaybeElement = props.supportedElements[props.message.format]
+  const rootMessage = props.messages[0]
+  const updateMessages = props.messages.slice(1)
 
+  const MaybeElement = props.supportedElements[rootMessage.format]
   return (
     <>
       {MaybeElement ? (
         React.createElement(MaybeElement, {
           sender: props.sender,
           ws: props.ws,
-          messageId: props.message.id,
-          conversationId: props.message.conversationId,
-          ...props.message.data,
-          ...(props.message.threadMessagesData && {
-            updatedData: props.message.threadMessagesData,
-          }),
+          messageId: rootMessage.id,
+          conversationId: rootMessage.conversationId,
+          ...rootMessage.data,
+          updatedData: updateMessages.map((message) => message.data),
         })
       ) : (
         <Typography variant="body2">
-          Unsupported element format: {props.message.format}
+          Unsupported element format: {rootMessage.format}
         </Typography>
       )}
     </>

--- a/src/components/elementRenderer/elementRenderer.tsx
+++ b/src/components/elementRenderer/elementRenderer.tsx
@@ -24,7 +24,9 @@ const ElementRenderer = (props: ElementRendererProps) => {
           messageId: rootMessage.id,
           conversationId: rootMessage.conversationId,
           ...rootMessage.data,
-          updatedData: updateMessages.map((message) => message.data),
+          ...(updateMessages.length > 0 && {
+            updatedData: updateMessages.map((message) => message.data),
+          }),
         })
       ) : (
         <Typography variant="body2">

--- a/src/components/input/textInput/textInput.stories.tsx
+++ b/src/components/input/textInput/textInput.stories.tsx
@@ -58,7 +58,8 @@ meta.argTypes = {
           'A websocket client with supports the following methods:\n' +
           'send: (msg: Message) => void\n' +
           'close: () => void\n' +
-          'reconnect: () => void',
+          'reconnect: () => void\n' +
+          'onReceive?: (handler: (message: Message) => void) => void',
       },
     },
   },

--- a/src/components/messageCanvas/actions/action.tsx
+++ b/src/components/messageCanvas/actions/action.tsx
@@ -5,13 +5,13 @@ import Tooltip from '@mui/material/Tooltip'
 import type { ReactNode } from 'react'
 import React from 'react'
 
-import type { ThreadableMessage } from '../../types'
+import type { Message } from '../../types'
 
 interface ActionProps {
   label: string
-  message: ThreadableMessage
+  message: Message
   icon: ReactNode
-  onClick: (message: ThreadableMessage) => void
+  onClick: (message: Message) => void
 }
 
 export default function Action(props: ActionProps) {

--- a/src/components/messageCanvas/actions/copy/copyText.tsx
+++ b/src/components/messageCanvas/actions/copy/copyText.tsx
@@ -1,18 +1,18 @@
 import React, { useState } from 'react'
 
 import Icon from '../../../icon/icon'
-import type { ThreadableMessage } from '../../../types'
+import type { Message } from '../../../types'
 import Action from '../index'
 
 export interface CopyTextProps {
-  message: ThreadableMessage
+  message: Message
 }
 
 export default function CopyText(props: CopyTextProps) {
   const [tooltipContent, setTooltipContent] = useState('Copy text')
   const twoSeconds = 2000
 
-  function handleOnClick(message: ThreadableMessage) {
+  function handleOnClick(message: Message) {
     if (message.data.text) {
       navigator.clipboard
         .writeText(message.data.text)

--- a/src/components/messageCanvas/actions/textToSpeech/textToSpeech.cy.tsx
+++ b/src/components/messageCanvas/actions/textToSpeech/textToSpeech.cy.tsx
@@ -1,8 +1,8 @@
-import type { ThreadableMessage } from '../../../types' // Adjust if needed
+import type { Message } from '../../../types' // Adjust if needed
 import TextToSpeech from './textToSpeech'
 
 describe('TextToSpeech Component', () => {
-  const mockMessage: ThreadableMessage = {
+  const mockMessage: Message = {
     id: '1',
     timestamp: '2020-01-02T00:00:00.000Z',
     conversationId: 'lkd9vc',

--- a/src/components/messageCanvas/actions/textToSpeech/textToSpeech.tsx
+++ b/src/components/messageCanvas/actions/textToSpeech/textToSpeech.tsx
@@ -1,11 +1,11 @@
 import React, { useState } from 'react'
 
 import Icon from '../../../icon/icon'
-import type { ThreadableMessage } from '../../../types'
+import type { Message } from '../../../types'
 import Action from '../index'
 
 export interface TextToSpeechProps {
-  message: ThreadableMessage
+  message: Message
 }
 
 export default function TextToSpeech(props: TextToSpeechProps) {

--- a/src/components/messageCanvas/messageCanvas.cy.tsx
+++ b/src/components/messageCanvas/messageCanvas.cy.tsx
@@ -6,7 +6,7 @@ import {
   testUser,
 } from '../../../cypress/support/variables'
 import Icon from '../icon/icon'
-import type { ThreadableMessage } from '../types'
+import type { Message } from '../types'
 import CopyText from './actions/copy/copyText'
 import MessageCanvas from './messageCanvas'
 
@@ -43,7 +43,7 @@ describe('MessageCanvas', () => {
       cy.mount(
         <MessageCanvas
           message={testMessage}
-          getActionsComponent={(message: ThreadableMessage) => {
+          getActionsComponent={(message: Message) => {
             const copyButton = message.format === 'text' && (
               <CopyText message={message} />
             )

--- a/src/components/messageCanvas/messageCanvas.stories.tsx
+++ b/src/components/messageCanvas/messageCanvas.stories.tsx
@@ -1,9 +1,11 @@
 import Typography from '@mui/material/Typography'
 import React from 'react'
 
-import { ElementRenderer, MarkedMarkdown, type ThreadableMessage } from '..'
+import ElementRenderer from '../elementRenderer'
 import Icon from '../icon/icon'
+import MarkedMarkdown from '../markdown'
 import Text from '../text/text'
+import type { Message } from '../types'
 import CopyText from './actions/copy/copyText'
 import TextToSpeech from './actions/textToSpeech/textToSpeech'
 import MessageCanvas from './messageCanvas'
@@ -111,7 +113,7 @@ const elementRendererString = `<ElementRenderer
       supportedElements={{ text: Text }}
     />`
 
-const profileString = `(message: ThreadableMessage) => {
+const profileString = `(message: Message) => {
     <>
       {getProfileIcon(message)}
       <Typography variant="body1" color="text.secondary">
@@ -120,7 +122,7 @@ const profileString = `(message: ThreadableMessage) => {
     </>
   }`
 
-function getProfileIcon(message: ThreadableMessage) {
+function getProfileIcon(message: Message) {
   if (message.sender.name?.includes('agent')) {
     return <Icon name="smart_toy" />
   } else {
@@ -128,7 +130,7 @@ function getProfileIcon(message: ThreadableMessage) {
   }
 }
 
-function getProfileName(message: ThreadableMessage) {
+function getProfileName(message: Message) {
   return (
     <Typography variant="body1" color="text.secondary">
       {message.sender.name}
@@ -136,7 +138,7 @@ function getProfileName(message: ThreadableMessage) {
   )
 }
 
-function getProfileIconAndName(message: ThreadableMessage) {
+function getProfileIconAndName(message: Message) {
   return (
     <>
       {getProfileIcon(message)}
@@ -149,7 +151,7 @@ export const WithProfileIcon = {
   args: {
     children: (
       <ElementRenderer
-        message={messageFromHuman}
+        messages={[messageFromHuman]}
         supportedElements={{ text: Text }}
         {...commonElementRendererProps}
       />
@@ -175,7 +177,7 @@ export const NoIcon = {
   args: {
     children: (
       <ElementRenderer
-        message={messageFromAgent}
+        messages={[messageFromAgent]}
         supportedElements={{ text: Text }}
         {...commonElementRendererProps}
       />
@@ -201,14 +203,14 @@ export const WithCopyIcon = {
   args: {
     children: (
       <ElementRenderer
-        message={messageFromHuman}
+        messages={[messageFromHuman]}
         supportedElements={{ text: Text }}
         {...commonElementRendererProps}
       />
     ),
     message: messageFromHuman,
     getProfileComponent: getProfileIconAndName,
-    getActionsComponent: (message: ThreadableMessage) => {
+    getActionsComponent: (message: Message) => {
       const copyButton = message.format === 'text' && (
         <CopyText message={message} />
       )
@@ -222,7 +224,7 @@ export const WithCopyIcon = {
       source: {
         code: `<MessageCanvas
   getProfileComponent={${profileString}}
-  getActionsComponent={(message: ThreadableMessage) => {
+  getActionsComponent={(message: Message) => {
     const copyButton = message.format === 'text' && <CopyText message={message} />
     if (copyButton) {
       return <>{copyButton}</>
@@ -241,14 +243,14 @@ export const WithTextToSpeech = {
   args: {
     children: (
       <ElementRenderer
-        message={markdownMessage}
+        messages={[markdownMessage]}
         supportedElements={{ markdown: MarkedMarkdown }}
         {...commonElementRendererProps}
       />
     ),
     message: markdownMessage,
     getProfileComponent: getProfileIconAndName,
-    getActionsComponent: (message: ThreadableMessage) => {
+    getActionsComponent: (message: Message) => {
       return (
         <>
           <TextToSpeech message={message} />
@@ -265,7 +267,7 @@ export const WithTextToSpeech = {
       source: {
         code: `<MessageCanvas
   getProfileComponent={${profileString}}
-  getActionsComponent={(message: ThreadableMessage) => {
+  getActionsComponent={(message: Message) => {
     const copyButton = message.format === 'text' && <CopyText message={message} />
     if (copyButton) {
       return <>{copyButton}</>

--- a/src/components/messageCanvas/messageCanvas.tsx
+++ b/src/components/messageCanvas/messageCanvas.tsx
@@ -6,23 +6,23 @@ import Stack from '@mui/material/Stack'
 import React, { forwardRef, type ReactNode } from 'react'
 
 import Timestamp from '../timestamp/timestamp'
-import type { ThreadableMessage } from '../types'
+import type { Message } from '../types'
 
 export interface MessageContainerProps {
   /** A function that returns a React element to display sender details, like names and/or avatars. */
-  getProfileComponent?: (message: ThreadableMessage) => ReactNode
+  getProfileComponent?: (message: Message) => ReactNode
   /** A function that returns a single React element which may be composed of several actions supported for the message, such as editing, copying, and deleting, etc.
    * In case no actions are applicable or available for a particular message, the function may return `undefined`.
    * This approach offers flexibility in tailoring message interactions to specific application requirements.
    * To define individual message actions, developers can extend the `Action` component's functionality.
    * One such example is the `CopyText` component.
    */
-  getActionsComponent?: (message: ThreadableMessage) => ReactNode | undefined
+  getActionsComponent?: (message: Message) => ReactNode | undefined
 }
 
 export interface MessageCanvasProps extends MessageContainerProps {
-  /** Message information to be displayed. Please see the `MessageSpace` docs for more information about the `ThreadableMessage` interface. */
-  message: ThreadableMessage
+  /** Message information to be displayed. Please see the `MessageSpace` docs for more information about the `Message` interface. */
+  message: Message
   /** React component to be displayed in the message canvas. */
   children: ReactNode
 }

--- a/src/components/messageSpace/messageSpace.cy.tsx
+++ b/src/components/messageSpace/messageSpace.cy.tsx
@@ -1,5 +1,6 @@
 import 'cypress-real-events'
 
+import { Server } from 'mock-socket'
 import { v4 as getUUID } from 'uuid'
 
 import {
@@ -21,6 +22,7 @@ import {
   YoutubeVideo,
 } from '..'
 import Icon from '../icon/icon'
+import { getMockWebSocketClient } from '../mockWebSocket'
 import MessageSpace from './messageSpace'
 
 describe('MessageSpace Component', () => {
@@ -80,7 +82,80 @@ describe('MessageSpace Component', () => {
   ]
 
   const messageSpace = '[data-cy=message-space]'
+  const webSocketUrl = 'ws://localhost:8082'
+  const streamingTextRootMessageId = getUUID()
+  const messagesToBeSent = [
+    {
+      ...humanMessageData,
+      id: getUUID(),
+      timestamp: new Date().toISOString(),
+      format: 'text',
+      data: {
+        text: 'Could you show me an example of the streaming text component?',
+      },
+    },
+    {
+      ...agentMessageData,
+      id: streamingTextRootMessageId,
+      timestamp: new Date().toISOString(),
+      format: 'streamingText',
+      data: {
+        text: 'Sure!',
+      },
+    },
+    {
+      ...agentMessageData,
+      id: getUUID(),
+      threadId: streamingTextRootMessageId,
+      timestamp: new Date().toISOString(),
+      format: 'updateStreamingText',
+      data: {
+        text: ' The text',
+      },
+    },
+    {
+      ...agentMessageData,
+      id: streamingTextRootMessageId,
+      threadId: streamingTextRootMessageId,
+      timestamp: new Date().toISOString(),
+      format: 'updateStreamingText',
+      data: {
+        text: ' is displayed',
+      },
+    },
+    {
+      ...agentMessageData,
+      id: streamingTextRootMessageId,
+      threadId: streamingTextRootMessageId,
+      timestamp: new Date().toISOString(),
+      format: 'updateStreamingText',
+      data: {
+        text: ' progressively.',
+      },
+    },
+  ]
 
+  let server: Server | null
+
+  const setupWebSocketServer = () => {
+    server = new Server(webSocketUrl)
+    const serverDelay = 50
+    server.on('connection', (socket) => {
+      messagesToBeSent.forEach((message, index) => {
+        setTimeout(
+          () => socket.send(JSON.stringify(message)),
+          serverDelay + index * serverDelay
+        )
+      })
+    })
+  }
+
+  const teardownWebSocketServer = () => {
+    if (server) {
+      server.stop()
+      server = null
+    }
+  }
   supportedViewports.forEach((viewport) => {
     it(`renders correctly with provided messages on ${viewport} screen`, () => {
       const mockWsClient = {
@@ -125,6 +200,51 @@ describe('MessageSpace Component', () => {
             })
         }
       })
+    })
+
+    it(`can receive and render messages from websocket on ${viewport} screen`, () => {
+      setupWebSocketServer()
+      cy.viewport(viewport)
+      cy.mount(
+        <MessageSpace
+          ws={getMockWebSocketClient(webSocketUrl)}
+          sender={testUser}
+          messages={[
+            {
+              ...humanMessageData,
+              id: getUUID(),
+              timestamp: '2024-01-02T00:00:00.000Z',
+              format: 'text',
+              data: {
+                text: 'Existing message',
+              },
+            },
+          ]}
+          supportedElements={supportedElements}
+          getProfileComponent={(message: Message) => {
+            if (message.sender.name?.includes('Agent')) {
+              return <Icon name="smart_toy" />
+            } else {
+              return <Icon name="account_circle" />
+            }
+          }}
+        />
+      )
+      const messageSpace = '[data-cy=message-space]'
+      cy.get(messageSpace).should('exist')
+      cy.get(messageSpace).should('contain', 'Existing message')
+      cy.get(messageSpace).should(
+        'not.contain',
+        'Sure! The text is displayed progressively.'
+      )
+      messagesToBeSent.forEach((message) => {
+        cy.get(messageSpace).should('contain', message.data.text)
+      })
+      cy.get(messageSpace).should(
+        'contain',
+        'Sure! The text is displayed progressively.'
+      )
+      teardownWebSocketServer()
     })
 
     it(`scrolls to bottom when "Go to bottom" button is clicked on ${viewport} screen`, () => {

--- a/src/components/messageSpace/messageSpace.cy.tsx
+++ b/src/components/messageSpace/messageSpace.cy.tsx
@@ -26,6 +26,8 @@ import { getMockWebSocketClient } from '../mockWebSocket'
 import MessageSpace from './messageSpace'
 
 describe('MessageSpace Component', () => {
+  const messageCanvas = '[data-cy=message-canvas]'
+
   const supportedElements = {
     text: Text,
     streamingText: StreamingText,
@@ -169,7 +171,7 @@ describe('MessageSpace Component', () => {
         <MessageSpace
           ws={mockWsClient}
           sender={testUser}
-          messages={messages}
+          receivedMessages={messages}
           supportedElements={supportedElements}
           getProfileComponent={(message: Message) => {
             if (message.sender.name?.includes('Agent')) {
@@ -202,14 +204,14 @@ describe('MessageSpace Component', () => {
       })
     })
 
-    it(`can receive and render messages from websocket on ${viewport} screen`, () => {
+    it.only(`can receive and render messages from websocket on ${viewport} screen`, () => {
       setupWebSocketServer()
       cy.viewport(viewport)
       cy.mount(
         <MessageSpace
           ws={getMockWebSocketClient(webSocketUrl)}
           sender={testUser}
-          messages={[
+          receivedMessages={[
             {
               ...humanMessageData,
               id: getUUID(),
@@ -237,6 +239,7 @@ describe('MessageSpace Component', () => {
         'not.contain',
         'Sure! The text is displayed progressively.'
       )
+      cy.get(messageCanvas).should('have.length', 1)
       messagesToBeSent.forEach((message) => {
         cy.get(messageSpace).should('contain', message.data.text)
       })
@@ -244,6 +247,8 @@ describe('MessageSpace Component', () => {
         'contain',
         'Sure! The text is displayed progressively.'
       )
+      const totalDisplayedMessages = 3
+      cy.get(messageCanvas).should('have.length', totalDisplayedMessages)
       teardownWebSocketServer()
     })
 
@@ -262,7 +267,7 @@ describe('MessageSpace Component', () => {
           <MessageSpace
             ws={mockWsClient}
             sender={testUser}
-            messages={messages}
+            receivedMessages={messages}
             supportedElements={supportedElements}
           />
         </div>

--- a/src/components/messageSpace/messageSpace.stories.tsx
+++ b/src/components/messageSpace/messageSpace.stories.tsx
@@ -197,7 +197,7 @@ const tableData = [
 ]
 
 const chartColors = ['#648FFF', '#785EF0', '#DC267F', '#FE6100', '#FFB000']
-
+const streamingMarkdownRootMessageId = getUUID()
 export const Default = {
   args: {
     ws: { send: () => {} },
@@ -214,11 +214,21 @@ export const Default = {
       },
       {
         ...agentMessageData,
-        id: getUUID(),
+        id: streamingMarkdownRootMessageId,
         timestamp: '2024-01-02T00:01:00.000Z',
-        format: 'markdown',
+        format: 'streamingMarkdown',
         data: {
-          text: '# Title\n\n---\n\n ## Subtitle\n\nThis is a paragraph. Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry\'s standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum.\n\n- This is an **inline notation**\n- This is a *inline notation*.\n- This is a _inline notation_.\n- This is a __inline notation__.\n- This is a ~~inline notation~~.\n\n```\nconst string = "Hello World"\nconst number = 123\n```\n\n> This is a blockquote.\n\n1. Item 1\n2. Item 2\n3. Item 3\n\n| Column 1 | Column 2 | Column 3 |\n| -------- | -------- | -------- |\n| Item 1   | Item 2   | Item 3   |',
+          text: '# Title\n\n---\n\n ## Subtitle',
+        },
+      },
+      {
+        ...agentMessageData,
+        id: getUUID(),
+        timestamp: '2024-01-02T00:02:01.000Z',
+        format: 'updateStreamingMarkdown',
+        threadId: streamingMarkdownRootMessageId,
+        data: {
+          text: '\n\nThis is a paragraph. Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry\'s standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum.\n\n- This is an **inline notation**\n- This is a *inline notation*.\n- This is a _inline notation_.\n- This is a __inline notation__.\n- This is a ~~inline notation~~.\n\n```\nconst string = "Hello World"\nconst number = 123\n```\n\n> This is a blockquote.\n\n1. Item 1\n2. Item 2\n3. Item 3\n\n| Column 1 | Column 2 | Column 3 |\n| -------- | -------- | -------- |\n| Item 1   | Item 2   | Item 3   |',
         },
       },
       {

--- a/src/components/messageSpace/messageSpace.stories.tsx
+++ b/src/components/messageSpace/messageSpace.stories.tsx
@@ -65,7 +65,7 @@ function getProfileIconAndName(message: Message) {
 }
 
 meta.argTypes = {
-  messages: {
+  receivedMessages: {
     table: {
       type: {
         summary: 'Array of Message.\n',
@@ -86,6 +86,8 @@ meta.argTypes = {
     },
   },
   ws: {
+    description:
+      'WebSocket connection to send and receive messages to and from a backend. The onReceive prop will override the default handler once it is set. If you need to use the WebSocket for purposes other than chat, you will need to create a separate WebSocket connection.',
     table: {
       type: {
         summary: 'WebSocketClient',
@@ -203,7 +205,7 @@ export const Default = {
   args: {
     ws: { send: () => {} },
     sender: humanMessageData.sender,
-    messages: [
+    receivedMessages: [
       {
         ...humanMessageData,
         id: getUUID(),

--- a/src/components/messageSpace/messageSpace.stories.tsx
+++ b/src/components/messageSpace/messageSpace.stories.tsx
@@ -90,7 +90,11 @@ meta.argTypes = {
       type: {
         summary: 'WebSocketClient',
         detail:
-          'send: (message: Message) => void\nclose: () => void\nreconnect: () => void\n',
+          'A websocket client with supports the following methods:\n' +
+          'send: (msg: Message) => void\n' +
+          'close: () => void\n' +
+          'reconnect: () => void\n' +
+          'onReceive?: (handler: (message: Message) => void) => void',
       },
     },
   },

--- a/src/components/messageSpace/messageSpace.stories.tsx
+++ b/src/components/messageSpace/messageSpace.stories.tsx
@@ -9,6 +9,7 @@ import {
   Image,
   MarkedMarkdown,
   MarkedStreamingMarkdown,
+  type Message,
   Multipart,
   OpenLayersMap,
   RechartsTimeSeries,
@@ -16,7 +17,6 @@ import {
   StreamingText,
   Table,
   Text,
-  type ThreadableMessage,
   Video,
   YoutubeVideo,
 } from '..'
@@ -45,7 +45,7 @@ const meta: Meta<React.ComponentProps<typeof MessageSpace>> = {
 
 export default meta
 
-function getProfileIcon(message: ThreadableMessage) {
+function getProfileIcon(message: Message) {
   if (message.sender.name?.toLowerCase().includes('agent')) {
     return <Icon name="smart_toy" />
   } else {
@@ -53,7 +53,7 @@ function getProfileIcon(message: ThreadableMessage) {
   }
 }
 
-function getProfileIconAndName(message: ThreadableMessage) {
+function getProfileIconAndName(message: Message) {
   return (
     <>
       {getProfileIcon(message)}
@@ -68,9 +68,9 @@ meta.argTypes = {
   messages: {
     table: {
       type: {
-        summary: 'Array of ThreadableMessage.\n',
+        summary: 'Array of Message.\n',
         detail:
-          'ThreadableMessage extends the Message interface which has the following fields:\n' +
+          'Message interface has the following fields:\n' +
           '  id: A string representing the unique identifier of the message.\n' +
           '  timestamp: A string representing the timestamp of the message.\n' +
           '  sender: An object representing the sender of the message. Refer to the `sender` prop.\n' +
@@ -81,10 +81,7 @@ meta.argTypes = {
           '  threadId: An optional string representing the identifier of the thread to which this message belongs.\n' +
           '  priority: An optional string representing the priority of the message.\n' +
           '  taggedParticipants: An optional array of strings representing the participants tagged in the message.\n' +
-          '  topic: An optional string representing the identifier of the topic associated with the message.\n' +
-          'Other than the fields described above, ThreadableMessage also has the following fields:\n' +
-          '  lastThreadMessage: An optional object of Message interface representing the last message in the thread.\n' +
-          '  threadMessagesData: An optional array of objects of type MessageData, which can contain any key-value pairs.',
+          '  topic: An optional string representing the identifier of the topic associated with the message.\n',
       },
     },
   },
@@ -477,7 +474,7 @@ export const Default = {
       multipart: Multipart,
     },
     getProfileComponent: getProfileIconAndName,
-    getActionsComponent: (message: ThreadableMessage) => {
+    getActionsComponent: (message: Message) => {
       const copyButton = message.format === 'text' && (
         <CopyText message={message} />
       )

--- a/src/components/messageSpace/messageSpace.tsx
+++ b/src/components/messageSpace/messageSpace.tsx
@@ -49,7 +49,9 @@ function getCombinedMessages(
 }
 
 /**
- The `MessageSpace` component uses `MessageCanvas` and `ElementRenderer` to render a list of messages. It serves as a container for individual message items, each encapsulated within a `MessageCanvas` for consistent styling and layout.
+ The `MessageSpace` component uses `MessageCanvas` and `ElementRenderer` to render a list of messages. It serves as a container for individual message items, each encapsulated within a `MessageCanvas` for consistent styling and layout. It can receive and process messages to dynamically update the displayed content.
+
+ The `MessageSpace` component can combine update messages with the original message and render them as a single message. For this to work, the `threadId` of the update message must match the `id` of the original message, and the format of the update message must include 'update'.
  
  Note: For more information about the `getActionsComponent` and `getProfileComponent` fields, refer to the [MessageCanvas' docs](http://localhost:6006/?path=/docs/rustic-ui-message-canvas-message-canvas--docs).
 */

--- a/src/components/messageSpace/messageSpace.tsx
+++ b/src/components/messageSpace/messageSpace.tsx
@@ -146,21 +146,6 @@ export default function MessageSpace(props: MessageSpaceProps) {
     scrollDownIfNeeded()
   }, [areVideosLoaded])
 
-  function scrollToLastMessage() {
-    if (getVideoStatus()) {
-      const lastMessage = scrollEndRef.current
-
-      if (lastMessage) {
-        // Use setTimeout to delay smooth scrolling
-        setTimeout(() => {
-          lastMessage.scrollIntoView({ block: 'start', inline: 'nearest' })
-        }, 0)
-      }
-    } else {
-      setTimeout(scrollToLastMessage, 1)
-    }
-  }
-
   useEffect(() => {
     const hasNewMessage =
       previousMessagesLength !== 0 &&
@@ -168,7 +153,7 @@ export default function MessageSpace(props: MessageSpaceProps) {
 
     if (isScrolledToBottom && hasNewMessage) {
       hideScrollButton()
-      scrollToLastMessage()
+      scrollDownIfNeeded()
     }
   }, [isScrolledToBottom, Object.keys(chatMessages).length])
 
@@ -181,7 +166,7 @@ export default function MessageSpace(props: MessageSpaceProps) {
     })
 
     setChatMessages(messageDict)
-  }, [props.messages])
+  }, [props.messages?.length])
 
   function handleIncomingMessage(message: Message) {
     setChatMessages((prevMessages) =>

--- a/src/components/promptBuilder/mockWebSocket.ts
+++ b/src/components/promptBuilder/mockWebSocket.ts
@@ -39,8 +39,11 @@ export function getMockWebSocketClient(webSocketUrl: string): WebSocketClient {
         ws = new WebSocket(webSocketUrl)
       }
     },
-    onReceive: (handler: (event: MessageEvent) => void) => {
-      ws.onmessage = handler
+    onReceive: (handler: (message: Message) => void) => {
+      ws.onmessage = (event) => {
+        const receivedMessage = JSON.parse(event.data)
+        handler(receivedMessage)
+      }
     },
   }
 }

--- a/src/components/promptBuilder/promptBuilder.cy.tsx
+++ b/src/components/promptBuilder/promptBuilder.cy.tsx
@@ -1,100 +1,100 @@
-import { Server } from 'mock-socket'
+// import { Server } from 'mock-socket'
 
-import Question from '../question/question'
-import { getMockWebSocketClient, sendMessageToClient } from './mockWebSocket'
-import PromptBuilder from './promptBuilder'
+// import Question from '../question/question'
+// import { getMockWebSocketClient, sendMessageToClient } from './mockWebSocket'
+// import PromptBuilder from './promptBuilder'
 
-const webSocketUrl = 'ws://localhost:8081'
-const server = new Server(webSocketUrl)
+// const webSocketUrl = 'ws://localhost:8081'
+// const server = new Server(webSocketUrl)
 
-server.on('connection', (socket) => {
-  sendMessageToClient(socket, 'question', {
-    title: 'What is your main goal?',
-    options: [
-      'grow my business',
-      'sell internationally',
-      'hire or train employees',
-    ],
-  })
+// server.on('connection', (socket) => {
+//   sendMessageToClient(socket, 'question', {
+//     title: 'What is your main goal?',
+//     options: [
+//       'grow my business',
+//       'sell internationally',
+//       'hire or train employees',
+//     ],
+//   })
 
-  socket.on('message', () => {
-    sendMessageToClient(socket, 'promptBuilder', {
-      isLastQuestion: true,
-    })
-  })
-})
+//   socket.on('message', () => {
+//     sendMessageToClient(socket, 'promptBuilder', {
+//       isLastQuestion: true,
+//     })
+//   })
+// })
 
-describe('PromptBuilder Component', () => {
-  const promptBuilder = '[data-cy=prompt-builder]'
-  const componentTitle = '[data-cy=component-title]'
-  const quitButton = '[data-cy=quit-button]'
-  const quitDialogTitle = '[data-cy=quit-dialog-title]'
-  const confirmQuitButton = '[data-cy=confirm-quit-button]'
-  const continueBuildButton = '[data-cy=continue-build-button]'
-  const nextQuestionButton = '[data-cy=next-question-button]'
-  const questionsButtonsContainer = '[data-cy=buttons-container]'
-  const loadingSpinner = '[data-cy=loading-spinner]'
-  const generateButton = '[data-cy=generate-button]'
-  const mockProps = {
-    sender: { name: 'user', id: '1234' },
-    messageId: '123',
-    supportedElements: { question: Question },
-  }
-  beforeEach(() => {
-    const stubbedFunctions = {
-      onCancel: cy.stub().as('onCancel'),
-      onSubmit: cy.stub().as('onSubmit'),
-      ws: getMockWebSocketClient(webSocketUrl),
-    }
-    cy.mount(<PromptBuilder {...mockProps} {...stubbedFunctions} />)
-  })
-  it('renders the component', () => {
-    cy.get(promptBuilder).should('be.visible')
-    cy.get(componentTitle).should('be.visible')
-    cy.get(quitButton).should('be.visible')
-    cy.get(nextQuestionButton).should('be.visible')
-  })
-  it('shows quit dialog when attempting to quit', () => {
-    cy.get(quitButton).click()
-    cy.get(quitDialogTitle).should('be.visible')
-  })
-  it('executes onClose when the user quits', () => {
-    cy.get(quitButton).click()
-    cy.get(confirmQuitButton).click()
-    cy.get('@onCancel').should('be.called')
-  })
-  it('does not quit when the user clicks "Continue build"', () => {
-    cy.get(quitButton).click()
-    cy.get(continueBuildButton).click()
-    cy.get(quitDialogTitle).should('not.be.visible')
-    cy.get(promptBuilder).should('be.visible')
-  })
-  it('should disable the "Next question" button when the user has not selected an option', () => {
-    cy.get(questionsButtonsContainer)
-      .children()
-      .each((button) => {
-        cy.wrap(button).should('have.attr', 'aria-disabled', 'false')
-      })
-    cy.get(nextQuestionButton).should('be.disabled')
-  })
-  it('should enable the "Next question" button when the user has selected an option', () => {
-    cy.get(questionsButtonsContainer).children().first().click()
-    cy.get(nextQuestionButton).should('not.be.disabled')
-  })
-  it('should not show the generate button when no message has indicated that it is ready', () => {
-    cy.get(generateButton).should('not.exist')
-  })
-  it('shows a loading indicator when waiting for the next question', () => {
-    cy.get(questionsButtonsContainer).children().first().click()
-    cy.get(nextQuestionButton).click()
-    cy.get(loadingSpinner).should('be.visible')
-  })
-  it('handles Generate button click', () => {
-    cy.get(questionsButtonsContainer).children().first().click()
-    cy.get(nextQuestionButton).click()
-    cy.get(generateButton).should('be.visible')
-    cy.get(generateButton).click()
-    cy.get(loadingSpinner).should('be.visible')
-    cy.get('@onSubmit').should('be.called')
-  })
-})
+// describe('PromptBuilder Component', () => {
+//   const promptBuilder = '[data-cy=prompt-builder]'
+//   const componentTitle = '[data-cy=component-title]'
+//   const quitButton = '[data-cy=quit-button]'
+//   const quitDialogTitle = '[data-cy=quit-dialog-title]'
+//   const confirmQuitButton = '[data-cy=confirm-quit-button]'
+//   const continueBuildButton = '[data-cy=continue-build-button]'
+//   const nextQuestionButton = '[data-cy=next-question-button]'
+//   const questionsButtonsContainer = '[data-cy=buttons-container]'
+//   const loadingSpinner = '[data-cy=loading-spinner]'
+//   const generateButton = '[data-cy=generate-button]'
+//   const mockProps = {
+//     sender: { name: 'user', id: '1234' },
+//     messageId: '123',
+//     supportedElements: { question: Question },
+//   }
+//   beforeEach(() => {
+//     const stubbedFunctions = {
+//       onCancel: cy.stub().as('onCancel'),
+//       onSubmit: cy.stub().as('onSubmit'),
+//       ws: getMockWebSocketClient(webSocketUrl),
+//     }
+//     cy.mount(<PromptBuilder {...mockProps} {...stubbedFunctions} />)
+//   })
+//   it('renders the component', () => {
+//     cy.get(promptBuilder).should('be.visible')
+//     cy.get(componentTitle).should('be.visible')
+//     cy.get(quitButton).should('be.visible')
+//     cy.get(nextQuestionButton).should('be.visible')
+//   })
+//   it('shows quit dialog when attempting to quit', () => {
+//     cy.get(quitButton).click()
+//     cy.get(quitDialogTitle).should('be.visible')
+//   })
+//   it('executes onClose when the user quits', () => {
+//     cy.get(quitButton).click()
+//     cy.get(confirmQuitButton).click()
+//     cy.get('@onCancel').should('be.called')
+//   })
+//   it('does not quit when the user clicks "Continue build"', () => {
+//     cy.get(quitButton).click()
+//     cy.get(continueBuildButton).click()
+//     cy.get(quitDialogTitle).should('not.be.visible')
+//     cy.get(promptBuilder).should('be.visible')
+//   })
+//   it('should disable the "Next question" button when the user has not selected an option', () => {
+//     cy.get(questionsButtonsContainer)
+//       .children()
+//       .each((button) => {
+//         cy.wrap(button).should('have.attr', 'aria-disabled', 'false')
+//       })
+//     cy.get(nextQuestionButton).should('be.disabled')
+//   })
+//   it('should enable the "Next question" button when the user has selected an option', () => {
+//     cy.get(questionsButtonsContainer).children().first().click()
+//     cy.get(nextQuestionButton).should('not.be.disabled')
+//   })
+//   it('should not show the generate button when no message has indicated that it is ready', () => {
+//     cy.get(generateButton).should('not.exist')
+//   })
+//   it('shows a loading indicator when waiting for the next question', () => {
+//     cy.get(questionsButtonsContainer).children().first().click()
+//     cy.get(nextQuestionButton).click()
+//     cy.get(loadingSpinner).should('be.visible')
+//   })
+//   it('handles Generate button click', () => {
+//     cy.get(questionsButtonsContainer).children().first().click()
+//     cy.get(nextQuestionButton).click()
+//     cy.get(generateButton).should('be.visible')
+//     cy.get(generateButton).click()
+//     cy.get(loadingSpinner).should('be.visible')
+//     cy.get('@onSubmit').should('be.called')
+//   })
+// })

--- a/src/components/promptBuilder/promptBuilder.cy.tsx
+++ b/src/components/promptBuilder/promptBuilder.cy.tsx
@@ -1,100 +1,100 @@
-// import { Server } from 'mock-socket'
+import { Server } from 'mock-socket'
 
-// import Question from '../question/question'
-// import { getMockWebSocketClient, sendMessageToClient } from './mockWebSocket'
-// import PromptBuilder from './promptBuilder'
+import Question from '../question/question'
+import { getMockWebSocketClient, sendMessageToClient } from './mockWebSocket'
+import PromptBuilder from './promptBuilder'
 
-// const webSocketUrl = 'ws://localhost:8081'
-// const server = new Server(webSocketUrl)
+const webSocketUrl = 'ws://localhost:8081'
+const server = new Server(webSocketUrl)
 
-// server.on('connection', (socket) => {
-//   sendMessageToClient(socket, 'question', {
-//     title: 'What is your main goal?',
-//     options: [
-//       'grow my business',
-//       'sell internationally',
-//       'hire or train employees',
-//     ],
-//   })
+server.on('connection', (socket) => {
+  sendMessageToClient(socket, 'question', {
+    title: 'What is your main goal?',
+    options: [
+      'grow my business',
+      'sell internationally',
+      'hire or train employees',
+    ],
+  })
 
-//   socket.on('message', () => {
-//     sendMessageToClient(socket, 'promptBuilder', {
-//       isLastQuestion: true,
-//     })
-//   })
-// })
+  socket.on('message', () => {
+    sendMessageToClient(socket, 'promptBuilder', {
+      isLastQuestion: true,
+    })
+  })
+})
 
-// describe('PromptBuilder Component', () => {
-//   const promptBuilder = '[data-cy=prompt-builder]'
-//   const componentTitle = '[data-cy=component-title]'
-//   const quitButton = '[data-cy=quit-button]'
-//   const quitDialogTitle = '[data-cy=quit-dialog-title]'
-//   const confirmQuitButton = '[data-cy=confirm-quit-button]'
-//   const continueBuildButton = '[data-cy=continue-build-button]'
-//   const nextQuestionButton = '[data-cy=next-question-button]'
-//   const questionsButtonsContainer = '[data-cy=buttons-container]'
-//   const loadingSpinner = '[data-cy=loading-spinner]'
-//   const generateButton = '[data-cy=generate-button]'
-//   const mockProps = {
-//     sender: { name: 'user', id: '1234' },
-//     messageId: '123',
-//     supportedElements: { question: Question },
-//   }
-//   beforeEach(() => {
-//     const stubbedFunctions = {
-//       onCancel: cy.stub().as('onCancel'),
-//       onSubmit: cy.stub().as('onSubmit'),
-//       ws: getMockWebSocketClient(webSocketUrl),
-//     }
-//     cy.mount(<PromptBuilder {...mockProps} {...stubbedFunctions} />)
-//   })
-//   it('renders the component', () => {
-//     cy.get(promptBuilder).should('be.visible')
-//     cy.get(componentTitle).should('be.visible')
-//     cy.get(quitButton).should('be.visible')
-//     cy.get(nextQuestionButton).should('be.visible')
-//   })
-//   it('shows quit dialog when attempting to quit', () => {
-//     cy.get(quitButton).click()
-//     cy.get(quitDialogTitle).should('be.visible')
-//   })
-//   it('executes onClose when the user quits', () => {
-//     cy.get(quitButton).click()
-//     cy.get(confirmQuitButton).click()
-//     cy.get('@onCancel').should('be.called')
-//   })
-//   it('does not quit when the user clicks "Continue build"', () => {
-//     cy.get(quitButton).click()
-//     cy.get(continueBuildButton).click()
-//     cy.get(quitDialogTitle).should('not.be.visible')
-//     cy.get(promptBuilder).should('be.visible')
-//   })
-//   it('should disable the "Next question" button when the user has not selected an option', () => {
-//     cy.get(questionsButtonsContainer)
-//       .children()
-//       .each((button) => {
-//         cy.wrap(button).should('have.attr', 'aria-disabled', 'false')
-//       })
-//     cy.get(nextQuestionButton).should('be.disabled')
-//   })
-//   it('should enable the "Next question" button when the user has selected an option', () => {
-//     cy.get(questionsButtonsContainer).children().first().click()
-//     cy.get(nextQuestionButton).should('not.be.disabled')
-//   })
-//   it('should not show the generate button when no message has indicated that it is ready', () => {
-//     cy.get(generateButton).should('not.exist')
-//   })
-//   it('shows a loading indicator when waiting for the next question', () => {
-//     cy.get(questionsButtonsContainer).children().first().click()
-//     cy.get(nextQuestionButton).click()
-//     cy.get(loadingSpinner).should('be.visible')
-//   })
-//   it('handles Generate button click', () => {
-//     cy.get(questionsButtonsContainer).children().first().click()
-//     cy.get(nextQuestionButton).click()
-//     cy.get(generateButton).should('be.visible')
-//     cy.get(generateButton).click()
-//     cy.get(loadingSpinner).should('be.visible')
-//     cy.get('@onSubmit').should('be.called')
-//   })
-// })
+describe('PromptBuilder Component', () => {
+  const promptBuilder = '[data-cy=prompt-builder]'
+  const componentTitle = '[data-cy=component-title]'
+  const quitButton = '[data-cy=quit-button]'
+  const quitDialogTitle = '[data-cy=quit-dialog-title]'
+  const confirmQuitButton = '[data-cy=confirm-quit-button]'
+  const continueBuildButton = '[data-cy=continue-build-button]'
+  const nextQuestionButton = '[data-cy=next-question-button]'
+  const questionsButtonsContainer = '[data-cy=buttons-container]'
+  const loadingSpinner = '[data-cy=loading-spinner]'
+  const generateButton = '[data-cy=generate-button]'
+  const mockProps = {
+    sender: { name: 'user', id: '1234' },
+    messageId: '123',
+    supportedElements: { question: Question },
+  }
+  beforeEach(() => {
+    const stubbedFunctions = {
+      onCancel: cy.stub().as('onCancel'),
+      onSubmit: cy.stub().as('onSubmit'),
+      ws: getMockWebSocketClient(webSocketUrl),
+    }
+    cy.mount(<PromptBuilder {...mockProps} {...stubbedFunctions} />)
+  })
+  it('renders the component', () => {
+    cy.get(promptBuilder).should('be.visible')
+    cy.get(componentTitle).should('be.visible')
+    cy.get(quitButton).should('be.visible')
+    cy.get(nextQuestionButton).should('be.visible')
+  })
+  it('shows quit dialog when attempting to quit', () => {
+    cy.get(quitButton).click()
+    cy.get(quitDialogTitle).should('be.visible')
+  })
+  it('executes onClose when the user quits', () => {
+    cy.get(quitButton).click()
+    cy.get(confirmQuitButton).click()
+    cy.get('@onCancel').should('be.called')
+  })
+  it('does not quit when the user clicks "Continue build"', () => {
+    cy.get(quitButton).click()
+    cy.get(continueBuildButton).click()
+    cy.get(quitDialogTitle).should('not.be.visible')
+    cy.get(promptBuilder).should('be.visible')
+  })
+  it('should disable the "Next question" button when the user has not selected an option', () => {
+    cy.get(questionsButtonsContainer)
+      .children()
+      .each((button) => {
+        cy.wrap(button).should('have.attr', 'aria-disabled', 'false')
+      })
+    cy.get(nextQuestionButton).should('be.disabled')
+  })
+  it('should enable the "Next question" button when the user has selected an option', () => {
+    cy.get(questionsButtonsContainer).children().first().click()
+    cy.get(nextQuestionButton).should('not.be.disabled')
+  })
+  it('should not show the generate button when no message has indicated that it is ready', () => {
+    cy.get(generateButton).should('not.exist')
+  })
+  it('shows a loading indicator when waiting for the next question', () => {
+    cy.get(questionsButtonsContainer).children().first().click()
+    cy.get(nextQuestionButton).click()
+    cy.get(loadingSpinner).should('be.visible')
+  })
+  it('handles Generate button click', () => {
+    cy.get(questionsButtonsContainer).children().first().click()
+    cy.get(nextQuestionButton).click()
+    cy.get(generateButton).should('be.visible')
+    cy.get(generateButton).click()
+    cy.get(loadingSpinner).should('be.visible')
+    cy.get('@onSubmit').should('be.called')
+  })
+})

--- a/src/components/promptBuilder/promptBuilder.cy.tsx
+++ b/src/components/promptBuilder/promptBuilder.cy.tsx
@@ -1,7 +1,7 @@
 import { Server } from 'mock-socket'
 
+import { getMockWebSocketClient, sendMessageToClient } from '../mockWebSocket'
 import Question from '../question/question'
-import { getMockWebSocketClient, sendMessageToClient } from './mockWebSocket'
 import PromptBuilder from './promptBuilder'
 
 const webSocketUrl = 'ws://localhost:8081'

--- a/src/components/promptBuilder/promptBuilder.stories.tsx
+++ b/src/components/promptBuilder/promptBuilder.stories.tsx
@@ -14,10 +14,10 @@ import { v4 as getUUID } from 'uuid'
 
 import TextInput from '../input/textInput/textInput'
 import MessageSpace from '../messageSpace/messageSpace'
+import { getMockWebSocketClient, sendMessageToClient } from '../mockWebSocket'
 import Question from '../question/question'
 import Text from '../text/text'
 import type { Message, QuestionProps } from '../types'
-import { getMockWebSocketClient, sendMessageToClient } from './mockWebSocket'
 import PromptBuilder from './promptBuilder'
 
 const meta: Meta<React.ComponentProps<typeof PromptBuilder>> = {

--- a/src/components/promptBuilder/promptBuilder.stories.tsx
+++ b/src/components/promptBuilder/promptBuilder.stories.tsx
@@ -301,7 +301,7 @@ export const Default = {
               ws={boilerplateWs}
               sender={user}
               supportedElements={{ text: Text }}
-              messages={messageSpaceMessages}
+              receivedMessages={messageSpaceMessages}
               getProfileComponent={(message) => {
                 return <>{message.sender.name}</>
               }}

--- a/src/components/promptBuilder/promptBuilder.stories.tsx
+++ b/src/components/promptBuilder/promptBuilder.stories.tsx
@@ -53,7 +53,7 @@ meta.argTypes = {
           'send: (msg: Message) => void\n' +
           'close: () => void\n' +
           'reconnect: () => void\n' +
-          'onReceive?:  (handler: (event: MessageEvent) => void) => void\n',
+          'onReceive?:  (handler: (message: Message) => void) => void',
       },
     },
   },

--- a/src/components/promptBuilder/promptBuilder.stories.tsx
+++ b/src/components/promptBuilder/promptBuilder.stories.tsx
@@ -85,7 +85,7 @@ meta.argTypes = {
     type: 'function',
     table: {
       type: {
-        summary: '(message: ThreadableMessage) => ReactNode',
+        summary: '(message: Message) => ReactNode',
       },
     },
   },

--- a/src/components/promptBuilder/promptBuilder.tsx
+++ b/src/components/promptBuilder/promptBuilder.tsx
@@ -55,9 +55,8 @@ export default function PromptBuilder(props: PromptBuilderProps) {
     },
   }
 
-  function handleIncomingMessage(event: MessageEvent) {
-    const receivedMessage = JSON.parse(event.data)
-    setMessages((prev) => [...prev, receivedMessage])
+  function handleIncomingMessage(message: Message) {
+    setMessages((prev) => [...prev, message])
   }
 
   useEffect(() => {
@@ -121,7 +120,7 @@ export default function PromptBuilder(props: PromptBuilderProps) {
               key={message.id}
               ws={inputCapturer}
               sender={props.sender}
-              message={message}
+              messages={message}
               supportedElements={props.supportedElements}
             />
           )

--- a/src/components/promptBuilder/promptBuilder.tsx
+++ b/src/components/promptBuilder/promptBuilder.tsx
@@ -120,7 +120,7 @@ export default function PromptBuilder(props: PromptBuilderProps) {
               key={message.id}
               ws={inputCapturer}
               sender={props.sender}
-              messages={message}
+              messages={[message]}
               supportedElements={props.supportedElements}
             />
           )

--- a/src/components/question/question.stories.tsx
+++ b/src/components/question/question.stories.tsx
@@ -32,7 +32,11 @@ meta.argTypes = {
       type: {
         summary: 'WebSocketClient',
         detail:
-          'send: (message: Message) => void\nclose: () => void\nreconnect: () => void\n',
+          'A websocket client with supports the following methods:\n' +
+          'send: (msg: Message) => void\n' +
+          'close: () => void\n' +
+          'reconnect: () => void\n' +
+          'onReceive?: (handler: (message: Message) => void) => void',
       },
     },
   },

--- a/src/components/types.ts
+++ b/src/components/types.ts
@@ -39,7 +39,7 @@ export interface WebSocketClient {
   send: (message: Message) => void
   close: () => void
   reconnect: () => void
-  onReceive?: (handler: (event: MessageEvent) => void) => void
+  onReceive?: (handler: (message: Message) => void) => void
 }
 
 export enum ParticipantRole {

--- a/src/components/types.ts
+++ b/src/components/types.ts
@@ -25,11 +25,6 @@ export interface Message {
   topic?: string
 }
 
-export interface ThreadableMessage extends Message {
-  lastThreadMessage?: Message
-  threadMessagesData?: MessageData[]
-}
-
 export interface ComponentMap {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   [key: string]: React.ComponentType<any>


### PR DESCRIPTION
## Changes

- Handle receiving and processing messages in `MessageSpace`
  - `props.messages` is used to pass unprocessed messages from the page level. `props.ws.onReceive` is used to receive and handle incoming messages from websocket. Original message and its update messages are combined into a single array and stored in the `chatMessages` (`{[messageId: string]: Message[]})`) for quick data retrieval.  
- Make relevant changes to ElementRenderer
  - `Message[]` which contains original message and update messages is passed to `ElementRenderer`. `ElementRenderer` renders component with original message as well as updated data from update messages. 
- Change the type for ws.onReceive from (handler: (event: MessageEvent) => void) => void to onReceive?: (handler: (message: Message) => void) => void. This enables parsing and transforming event data at the application level, reducing code repetition. 
- `PromptBuilder` is updated since it uses `elementRenderer`.
- Remove `ThreadableMessage`
- Update tests and stories

## Screenshots
### Before
<img width="854" alt="Screenshot 2024-07-31 at 4 48 42 PM" src="https://github.com/user-attachments/assets/cc658c3e-e2c1-4652-9a7d-320dc81412a7">

### After
<img width="979" alt="Screenshot 2024-08-01 at 10 39 05 AM" src="https://github.com/user-attachments/assets/9e90b3ad-bbae-4dc2-b343-d0747f502db3">

<img width="938" alt="Screenshot 2024-08-01 at 10 39 49 AM" src="https://github.com/user-attachments/assets/17e68704-b6d5-4492-bb1f-ef7d832b3ce5">

