### PR TITLE
fix: support showing long names

### DIFF
--- a/src/components/filePreview/filePreview.css
+++ b/src/components/filePreview/filePreview.css
@@ -2,10 +2,17 @@
   position: relative;
   display: flex;
   align-items: center;
-  padding: 8px 8px 8px 16px;
+  padding: 8px 16px;
   justify-content: space-between;
-  width: 220px;
   height: 56px;
+}
+
+.rustic-fixed-file-preview-width {
+  width: 220px;
+}
+
+.rustic-flexible-file-preview-width {
+  min-width: 220px;
 }
 
 .rustic-file-preview-modal {

--- a/src/components/filePreview/filePreview.tsx
+++ b/src/components/filePreview/filePreview.tsx
@@ -17,6 +17,7 @@ import type { FileData } from '../types'
 export interface FilePreviewProps {
   file: FileData
   supportedViewers?: { [key: string]: React.ComponentType<{ url: string }> }
+  showFullName?: boolean
 }
 
 const supportedViewers: {
@@ -53,17 +54,26 @@ export default function FilePreview(
     fileType && props.supportedViewers ? props.supportedViewers[fileType] : null
   const hasModalContent = !!ModalContentComponent
 
+  const filePreviewWidthStyle = props.showFullName
+    ? 'rustic-flexible-file-preview-width'
+    : 'rustic-fixed-file-preview-width'
+  const filePreviewCursorStyle = hasModalContent ? ' rustic-cursor-pointer' : ''
+  const FilePreviewClassName = `rustic-file-preview ${filePreviewWidthStyle}${filePreviewCursorStyle}`
+
+  const fileName = props.showFullName
+    ? props.file.name
+    : shortenString(props.file.name, maximumFileNameLength)
   return (
     <>
       <Card
-        className={`rustic-file-preview${hasModalContent ? ' rustic-cursor-pointer' : ''}`}
+        className={FilePreviewClassName}
         data-cy="file-preview"
         variant="outlined"
         sx={{ boxShadow: theme.shadows[1] }}
         onClick={handleFileClick}
       >
         <Typography variant="subtitle2" data-cy="file-name">
-          {shortenString(props.file.name, maximumFileNameLength)}
+          {fileName}
         </Typography>
         <div onClick={(e) => e.stopPropagation()}>{props.children}</div>
       </Card>

--- a/src/components/input/multimodal/multimodalInput/multimodalInput.stories.tsx
+++ b/src/components/input/multimodal/multimodalInput/multimodalInput.stories.tsx
@@ -125,6 +125,13 @@ multiModalInputMeta.argTypes = {
       type: { summary: 'number' },
     },
   },
+  showFullName: {
+    description:
+      'Optional props. Setting this to `true` will display long file names in full. If set to `false`, long names will be shortened.',
+    table: {
+      type: { summary: 'boolean' },
+    },
+  },
 }
 
 export default multiModalInputMeta

--- a/src/components/input/multimodal/multimodalInput/multimodalInput.tsx
+++ b/src/components/input/multimodal/multimodalInput/multimodalInput.tsx
@@ -102,6 +102,7 @@ export default function MultimodalInput(props: MultimodalInputProps) {
             messageId={messageId}
             filePreviewsContainer={filePreviewsContainer}
             errorMessagesContainer={errorMessagesContainer}
+            showFullName={props.showFullName}
           />
         </Box>
       </BaseInput>

--- a/src/components/input/multimodal/uploader/uploader.tsx
+++ b/src/components/input/multimodal/uploader/uploader.tsx
@@ -252,7 +252,11 @@ function Uploader(props: UploaderProps) {
   const filePreviews = (
     <Box className="rustic-files rustic-padding-16">
       {addedFiles.map((file, index) => (
-        <FilePreview file={{ name: file.name }} key={index}>
+        <FilePreview
+          file={{ name: file.name }}
+          showFullName={props.showFullName}
+          key={index}
+        >
           <Box className="rustic-flex-center">
             {file.loadingProgress < maximumLoadingProgress && (
               <LinearProgress
@@ -267,7 +271,7 @@ function Uploader(props: UploaderProps) {
                 data-cy="delete-button"
                 color="primary"
                 onClick={() => handleDelete(file, index)}
-                className="rustic-delete-button"
+                className="rustic-delete-button rustic-shift-to-right-by-8"
                 aria-label="cancel file upload"
               >
                 <span className="material-symbols-rounded">cancel</span>

--- a/src/components/multipart/multipart.stories.tsx
+++ b/src/components/multipart/multipart.stories.tsx
@@ -52,3 +52,14 @@ export const FileWithURL = {
     ],
   },
 }
+
+export const FilesWithLongName = {
+  args: {
+    text: 'This is a multipart message with text',
+    showFullName: true,
+    files: [
+      { name: 'File example with really long name.pdf' },
+      { name: 'Short name example.pdf' },
+    ],
+  },
+}

--- a/src/components/multipart/multipart.tsx
+++ b/src/components/multipart/multipart.tsx
@@ -16,9 +16,9 @@ export default function Multipart(props: MultipartProps) {
   function renderFiles() {
     const files = props.files.map((file, index) => {
       return (
-        <FilePreview file={file} key={index}>
+        <FilePreview file={file} showFullName={props.showFullName} key={index}>
           {file.url && (
-            <Tooltip title="Download">
+            <Tooltip title="Download" className="rustic-shift-to-right-by-8">
               <IconButton
                 component="a"
                 href={file.url}

--- a/src/components/types.ts
+++ b/src/components/types.ts
@@ -226,6 +226,8 @@ export interface MultipartProps extends MultipartData {
    * which viewer component should be used to open and display the file within the modal.
    */
   supportedViewers?: { [key: string]: React.ComponentType<{ url: string }> }
+  /** Setting this to true will display long file names in full. If set to false, long names will be shortened. */
+  showFullName?: boolean
 }
 
 export interface BaseInputProps {
@@ -278,6 +280,8 @@ export interface UploaderProps {
   maxFileCount?: number
   /** The maximum size for each uploaded file, in bytes. */
   maxFileSize?: number
+  /** Setting this to true will display long file names in full. If set to false, long names will be shortened. */
+  showFullName?: boolean
 }
 
 export type MultimodalInputProps = TextInputProps &

--- a/src/index.css
+++ b/src/index.css
@@ -31,3 +31,7 @@ code {
 .rustic-align-self-center {
   align-self: center;
 }
+
+.rustic-shift-to-right-by-8 {
+  margin-right: -8px;
+}


### PR DESCRIPTION
## Changes
- Add `showFullName` props to support showing long names

## Before
<img width="639" alt="Screenshot 2024-09-06 at 5 13 19 PM" src="https://github.com/user-attachments/assets/2fb0c039-d792-4447-8cd6-e94ff088822f">


## After
<img width="643" alt="Screenshot 2024-09-06 at 5 12 22 PM" src="https://github.com/user-attachments/assets/28e2459e-0f84-456e-905a-3cec96793c8d">
