### PR TITLE
fix(vegalite): render description as markdown

### DIFF
--- a/src/components/visualization/vegaLiteViz/vegaLiteViz.stories.tsx
+++ b/src/components/visualization/vegaLiteViz/vegaLiteViz.stories.tsx
@@ -628,7 +628,7 @@ export const WeatherPlot = {
 export const IsotypeGrid = {
   args: {
     title: 'Isotype Grid',
-    description: 'Drag region to select.',
+    description: '**Drag region to select**.',
     spec: {
       $schema: 'https://vega.github.io/schema/vega-lite/v5.json',
       width: 'container',

--- a/src/components/visualization/vegaLiteViz/vegaLiteViz.tsx
+++ b/src/components/visualization/vegaLiteViz/vegaLiteViz.tsx
@@ -9,15 +9,16 @@ import React, { useEffect, useRef, useState } from 'react'
 import { renderToStaticMarkup } from 'react-dom/server'
 import { default as VegaEmbed } from 'vega-embed'
 
+import MarkedMarkdown from '../../markdown/markedMarkdown'
 import PopoverMenu, { type PopoverMenuItem } from '../../menu/popoverMenu'
 import type { VegaLiteData } from './vegaLiteViz.types'
 
 /** The `VegaLiteViz` component is a versatile tool for visualizing data using the Vega-Lite grammar. With support for various graphic types, it empowers users to create engaging and informative data visualizations effortlessly.
  *
- * Note: `vega-embed` is not bundled, so please install the following package using npm:
+ * Note: `vega-embed`, `marked` and `dompurify` are not bundled, so please install the following packages using npm:
  *
  * ```typescript
- * npm i vega-embed
+ * npm i vega-embed marked dompurify
  * ```
  */
 function VegaLiteViz(props: VegaLiteData) {
@@ -134,9 +135,7 @@ function VegaLiteViz(props: VegaLiteData) {
         </Box>
 
         {props.title && <Typography variant="h6">{props.title}</Typography>}
-        {props.description && (
-          <Typography variant="body1">{props.description}</Typography>
-        )}
+        {props.description && <MarkedMarkdown text={props.description} />}
         <Box textAlign="center" mt={1}>
           {typeof props.spec.title === 'string' && (
             <Typography variant="subtitle2">{props.spec.title}</Typography>


### PR DESCRIPTION
## Change 
- Show markdown for description

## Before
<img width="555" alt="Screenshot 2024-10-30 at 2 12 38 PM" src="https://github.com/user-attachments/assets/35bc332b-85da-426e-8e7e-f384764f51d8">

## After
<img width="559" alt="Screenshot 2024-10-30 at 2 12 24 PM" src="https://github.com/user-attachments/assets/47a67bea-8af8-48f4-8850-118721d4a16d">
