### PR TITLE
docs: remove perspective version

### DIFF
--- a/src/components/visualization/perspectiveViz/perspectiveViz.tsx
+++ b/src/components/visualization/perspectiveViz/perspectiveViz.tsx
@@ -60,7 +60,7 @@ export function transformTableData(
  * Note: [Perspective](https://perspective.finos.org/) libraries are not bundled, so they must be included in the application's build process:
  *
  * ```typescript
- * npm i @finos/perspective@^2.10.1 @finos/perspective-viewer@^2.10.1 @finos/perspective-viewer-d3fc@^2.10.1 @finos/perspective-viewer-datagrid@^2.10.1
+ * npm i @finos/perspective @finos/perspective-viewer @finos/perspective-viewer-d3fc @finos/perspective-viewer-datagrid
  * ```
  */
 function PerspectiveViz(props: TableData) {


### PR DESCRIPTION
## Changes
- Remove perspective version from the installation instruction

## Before
<img width="934" alt="Screenshot 2024-10-31 at 1 40 37 PM" src="https://github.com/user-attachments/assets/95f90585-dab2-458d-a2c4-82302563a603">

## After
<img width="947" alt="Screenshot 2024-10-31 at 1 40 19 PM" src="https://github.com/user-attachments/assets/a267f729-dcaa-4182-b38b-42354653f84c">
