### PR TITLE
fix(input): add popover menu to multimodalInput and uploader

### DIFF
--- a/src/components/input/multimodal/multimodalInput/multimodalInput.cy.tsx
+++ b/src/components/input/multimodal/multimodalInput/multimodalInput.cy.tsx
@@ -41,6 +41,20 @@ describe('Input', () => {
         getUploadData={() => {
           return { userId: testUser.id }
         }}
+        uploadOptions={[
+          {
+            label: 'Upload Excel Sheet',
+            iconName: 'request_quote',
+            metadata: { file_meta: '{"uploadedBy":"id","category":"Finance"}' },
+          },
+          {
+            label: 'Upload Video',
+            iconName: 'movie',
+            metadata: { file_meta: '{"uploadedBy":"id","category": "Video"}' },
+            acceptedFileTypes:
+              '.mp4, .mov, .avi, .mkv, .wmv, .flv, .webm, .m4v',
+          },
+        ]}
       />
     )
   })
@@ -331,6 +345,35 @@ describe('Input', () => {
           'Failed to upload image-component-example.png. Please try again later'
         )
         cy.get(fileName).should('not.exist')
+      })
+    })
+
+    it(`displays upload options correctly on ${viewport} screen`, () => {
+      cy.viewport(viewport)
+      cy.get(uploadButton).click()
+      cy.contains('Upload Excel Sheet').should('be.visible')
+      cy.contains('Upload Video').should('be.visible')
+    })
+
+    it('uploads file with correct metadata', () => {
+      cy.viewport(viewport)
+
+      cy.intercept(
+        {
+          method: 'POST',
+          url: '/upload?message-id=*',
+        },
+        { url: '' }
+      ).as('upload')
+      cy.get(uploadButton).click()
+      cy.contains('Upload Video').click()
+      cy.get('input[type=file]').selectFile([videoFile], {
+        force: true,
+      })
+      cy.wait('@upload').interceptFormData((formData) => {
+        expect(formData['file_meta']).to.eq(
+          '{"uploadedBy":"id","category": "Video"}'
+        )
       })
     })
   })

--- a/src/components/input/multimodal/multimodalInput/multimodalInput.stories.tsx
+++ b/src/components/input/multimodal/multimodalInput/multimodalInput.stories.tsx
@@ -139,6 +139,21 @@ multiModalInputMeta.argTypes = {
       type: { summary: '(fileName: string) => { [key: string]: any }' },
     },
   },
+  uploadOptions: {
+    description:
+      'Optional props. Defines the available options for file upload, displayed within a popover menu. If no options are provided, an upload icon button will be displayed by default.',
+    table: {
+      type: {
+        summary: 'An array of UploadOption.\n',
+        detail:
+          'Each UploadOption has the following fields:\n' +
+          '  label: The text label displayed for the upload option, shown in the popover menu.\n' +
+          '  metadata: Metadata associated with this upload option, provided as key-value pairs. This data is typically sent along with the uploaded file to provide additional context or configuration.\n' +
+          '  acceptedFileTypes: Optional props. Specifies the types of files accepted for this upload option, formatted as a comma-separated string. If not provided, acceptedFileTypes for the entire component will be applied. \n' +
+          '  iconName: Optional props. The name of the Material Symbol to display alongside this upload option.',
+      },
+    },
+  },
 }
 
 export default multiModalInputMeta
@@ -182,7 +197,7 @@ export const PDFAndImageOnly = {
     ...Default.args,
     acceptedFileTypes: 'image/*,.pdf',
     getUploadData: () => {
-      return { userId: 'testUserId' }
+      return { file_meta: '{ "uploadedBy": "testId" }' }
     },
   },
 }
@@ -205,5 +220,28 @@ export const SpeechToText = {
   args: {
     ...Default.args,
     enableSpeechToText: true,
+  },
+}
+
+export const HasMenu = {
+  args: {
+    ...Default.args,
+    acceptedFileTypes: '.xlsx, .xls, .csv',
+    getUploadData: () => {
+      return { file_meta: '{ "uploadedBy": "testId" }' }
+    },
+    uploadOptions: [
+      {
+        label: 'Upload Excel Sheet',
+        iconName: 'request_quote',
+        metadata: { file_meta: '{"uploadedBy":"id","category":"Finance"}' },
+      },
+      {
+        label: 'Upload Video',
+        iconName: 'movie',
+        metadata: { file_meta: '{"uploadedBy":"id","category": "Video"}' },
+        acceptedFileTypes: '.mp4, .mov, .avi, .mkv, .wmv, .flv, .webm, .m4v',
+      },
+    ],
   },
 }

--- a/src/components/input/multimodal/multimodalInput/multimodalInput.tsx
+++ b/src/components/input/multimodal/multimodalInput/multimodalInput.tsx
@@ -104,6 +104,7 @@ export default function MultimodalInput(props: MultimodalInputProps) {
             errorMessagesContainer={errorMessagesContainer}
             showFullName={props.showFullName}
             getUploadData={props.getUploadData}
+            uploadOptions={props.uploadOptions}
           />
         </Box>
       </BaseInput>

--- a/src/components/types.ts
+++ b/src/components/types.ts
@@ -261,6 +261,13 @@ export interface TextInputProps
   ws: WebSocketClient
 }
 
+export interface UploadOption {
+  label: string
+  metadata: { [key: string]: any }
+  acceptedFileTypes?: string
+  iconName?: string
+}
+
 export interface UploaderProps {
   /** The types of files that are allowed to be selected for upload. For safety reasons, only allow file types that can be handled by your server. Avoid accepting executable file types like .exe, .bat, or .msi. For more information, refer to the [mdn web docs](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/file#unique_file_type_specifiers). */
   acceptedFileTypes: string
@@ -284,6 +291,8 @@ export interface UploaderProps {
   showFullName?: boolean
   /** A function that can be used to define additional data to be sent along with the file upload. */
   getUploadData?: (fileName: string) => { [key: string]: any }
+  /** Defines the available options for file upload, displayed within a popover menu. If no options are provided, an upload icon button will be displayed by default.*/
+  uploadOptions?: UploadOption[]
 }
 
 export type MultimodalInputProps = TextInputProps &


### PR DESCRIPTION
## Changes
- Support rendering upload options (Able to add accepted file types, label, icon name and metadata for each option)
- Update tests and storybook

## Screenshots
<img width="588" alt="Screenshot 2024-11-02 at 3 49 15 PM" src="https://github.com/user-attachments/assets/f6360104-b456-489d-8aaf-c2946785ca40">

![Screenshot 2024-11-02 at 2 21 07 PM](https://github.com/user-attachments/assets/91ae0dbb-d09a-473e-8433-fac2359ea589)

![Screenshot 2024-11-02 at 2 22 13 PM](https://github.com/user-attachments/assets/77aa9e90-eb0c-427c-a87f-e46523bb340a)
