### PR TITLE
fix(uploader): handle 409 error

### DIFF
--- a/src/components/input/multimodal/multimodalInput/multimodalInput.stories.tsx
+++ b/src/components/input/multimodal/multimodalInput/multimodalInput.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryFn } from '@storybook/react'
+import axios from 'axios'
 import React from 'react'
 import { v4 as getUUID } from 'uuid'
 
@@ -20,6 +21,40 @@ const multiModalInputMeta: Meta<React.ComponentProps<typeof MultimodalInput>> =
           status: 200,
           response: { fileId: getUUID() },
           delay: 1000,
+        },
+        {
+          url: 'http://localhost:8080/:messageId/files',
+          method: 'GET',
+          status: 200,
+          response: [
+            {
+              id: 'T7eVTLcNUtKGLC8R3iZAVr',
+              name: 'test.xlsx',
+              metadata: {
+                content_length: 117496,
+                uploaded_at: '2024-11-29T20:04:35.480280+00:00',
+              },
+              url: 'test.xlsx',
+              mimetype:
+                'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+              encoding: null,
+              on_filesystem: true,
+            },
+            {
+              id: 'T7eVTLcNUtKGLC8R3iZAVd',
+              name: 'test(1).xlsx',
+              metadata: {
+                content_length: 117496,
+                uploaded_at: '2024-11-30T20:04:35.480280+00:00',
+              },
+              url: 'test1.xlsx',
+              mimetype:
+                'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+              encoding: null,
+              on_filesystem: true,
+            },
+          ],
+          delay: 200,
         },
         {
           url: 'http://localhost:8080/files/:fileName',
@@ -154,6 +189,13 @@ multiModalInputMeta.argTypes = {
       },
     },
   },
+  listFiles: {
+    description:
+      'Optional props. A function to fetch and format existing file names when a file upload fails due to a conflict error (HTTP status code 409). The returned value will be used to determine a unique file name by appending an incremented number to the base name.',
+    table: {
+      type: { summary: 'Promise<string[]>' },
+    },
+  },
 }
 
 export default multiModalInputMeta
@@ -185,10 +227,16 @@ export const Default = {
         )
       },
     },
+    listFiles: () => {
+      return axios.get(`http://localhost:8080/123/files`).then((res) => {
+        const fileNames = res.data.map((file: any) => file.name)
+        return fileNames
+      })
+    },
     uploadFileEndpoint: 'http://localhost:8080/upload?message-id=:messageId',
     deleteFileEndpoint: 'http://localhost:8080/files/fileName',
     acceptedFileTypes:
-      'image/*,.pdf,.doc,.docx,application/x-iwork-pages-sffpages',
+      'image/*,.pdf,.doc,.docx,.xlsx,application/x-iwork-pages-sffpages',
   },
 }
 

--- a/src/components/input/multimodal/multimodalInput/multimodalInput.tsx
+++ b/src/components/input/multimodal/multimodalInput/multimodalInput.tsx
@@ -105,6 +105,7 @@ export default function MultimodalInput(props: MultimodalInputProps) {
             showFullName={props.showFullName}
             getUploadData={props.getUploadData}
             uploadOptions={props.uploadOptions}
+            listFiles={props.listFiles}
           />
         </Box>
       </BaseInput>

--- a/src/components/input/multimodal/uploader/uploader.tsx
+++ b/src/components/input/multimodal/uploader/uploader.tsx
@@ -80,7 +80,7 @@ function Uploader(props: UploaderProps) {
     ])
   }
 
-  function handleFilesChange(event: React.ChangeEvent<HTMLInputElement>) {
+  function handleFilesChange(event: React.ChangeEvent<HTMLInputElement>): void {
     setErrorMessages([])
 
     const files = event.target.files && Array.from(event.target.files)
@@ -104,7 +104,7 @@ function Uploader(props: UploaderProps) {
     event.target.value = ''
   }
 
-  function handleFile(file: File) {
+  function handleFile(file: File): void {
     const isFileSizeExceedingLimit =
       props.maxFileSize && file.size > props.maxFileSize
 
@@ -119,7 +119,7 @@ function Uploader(props: UploaderProps) {
     fileName: string,
     fileId: string,
     errorData: any
-  ) {
+  ): void {
     fileNamesRef.current = {
       ...fileNamesRef.current,
       [fileName]: fileNamesRef.current[fileName]--,
@@ -127,7 +127,7 @@ function Uploader(props: UploaderProps) {
     handleFailedUpload(fileName, fileId, errorData)
   }
 
-  function updateProgress(loadedPercentage: number, id: string) {
+  function updateProgress(loadedPercentage: number, id: string): void {
     setAddedFiles((prevFiles) => {
       const updatedFiles = prevFiles.map((file) => {
         if (file.id === id) {
@@ -142,7 +142,7 @@ function Uploader(props: UploaderProps) {
     })
   }
 
-  function handleSuccessfulUpload(res: { fileId: string }, id: string) {
+  function handleSuccessfulUpload(res: { fileId: string }, id: string): void {
     setAddedFiles((existingFiles) => {
       const index = existingFiles.findIndex((file) => file.id === id)
       if (index !== -1) {
@@ -161,7 +161,7 @@ function Uploader(props: UploaderProps) {
     fileName: string,
     id: string,
     response?: { message?: string }
-  ) {
+  ): void {
     setErrorMessages((prevMessages) => [
       ...prevMessages,
       `Failed to upload ${fileName}. ${response?.message || ''}`,
@@ -169,7 +169,7 @@ function Uploader(props: UploaderProps) {
     setAddedFiles((prev) => prev.filter((file) => file.id !== id))
   }
 
-  function getFileName(file: File) {
+  function getFileName(file: File): string {
     let fileName = file.name
     const fileNameCount = fileNamesRef.current[fileName]
 
@@ -187,7 +187,7 @@ function Uploader(props: UploaderProps) {
     return fileName
   }
 
-  function uploadFile(file: File) {
+  function uploadFile(file: File): void {
     const formData = new FormData()
     const controller = new AbortController()
 
@@ -330,7 +330,7 @@ function Uploader(props: UploaderProps) {
     uploadFile()
   }
 
-  function handleDelete(file: FileInfo, index: number) {
+  function handleDelete(file: FileInfo, index: number): void {
     setErrorMessages([])
     const fileName = file.name
     fileNamesRef.current = {
@@ -419,7 +419,7 @@ function Uploader(props: UploaderProps) {
   function renderContentWithRef(
     content: JSX.Element,
     domNode?: HTMLDivElement | null
-  ) {
+  ): JSX.Element {
     if (domNode) {
       return createPortal(content, domNode)
     } else {
@@ -427,7 +427,7 @@ function Uploader(props: UploaderProps) {
     }
   }
 
-  function handleMenuClick(option: UploadOption) {
+  function handleMenuClick(option: UploadOption): void {
     setAdditionalMetadata(option.metadata)
     const fileInput = document.getElementById(inputId) as HTMLInputElement
     if (fileInput) {

--- a/src/components/types.ts
+++ b/src/components/types.ts
@@ -293,6 +293,8 @@ export interface UploaderProps {
   getUploadData?: (fileName: string) => { [key: string]: any }
   /** Defines the available options for file upload, displayed within a popover menu. If no options are provided, an upload icon button will be displayed by default.*/
   uploadOptions?: UploadOption[]
+  /** A function to fetch and format existing file names when a file upload fails due to a conflict error (HTTP status code 409). The returned value will be used to determine a unique file name by appending an incremented number to the base name.  */
+  listFiles?: () => Promise<string[]>
 }
 
 export type MultimodalInputProps = TextInputProps &


### PR DESCRIPTION
## Change
- handle 409 uploading error by adding a new function props to fetch existing files and update file name accordingly
- update cypress and storybook

## Screenshot 
![Dec-02-2024 11-31-11](https://github.com/user-attachments/assets/874df2ee-72f2-4bc1-9e76-b3fbb6b5ea84)
<img width="637" alt="Screenshot 2024-12-02 at 2 43 35 PM" src="https://github.com/user-attachments/assets/1e42b0c1-9a58-4c7e-8580-9e042e550da5">
