### PR TITLE
fix: configure expansion depth

### DIFF
--- a/src/components/types.ts
+++ b/src/components/types.ts
@@ -176,7 +176,6 @@ export type TableConfig = {
   aggregates?: { [columnName: string]: TableAggregateOption }
   sort?: TableSort[]
   filter?: TableFilter[]
-  expandAll?: boolean
   expansionDepth?: number
 }
 

--- a/src/components/types.ts
+++ b/src/components/types.ts
@@ -176,6 +176,8 @@ export type TableConfig = {
   aggregates?: { [columnName: string]: TableAggregateOption }
   sort?: TableSort[]
   filter?: TableFilter[]
+  expandAll?: boolean
+  expansionDepth?: number
 }
 
 export interface TableFormat extends VisualizationFormat {

--- a/src/components/visualization/perspectiveViz/perspectiveViz.stories.tsx
+++ b/src/components/visualization/perspectiveViz/perspectiveViz.stories.tsx
@@ -38,6 +38,14 @@ meta.argTypes = {
         summary: 'TableConfig.',
         detail:
           'TableConfig has the following optional fields:\n' +
+          '  expandAll: A boolean that determines whether \n' +
+          '    all rows and columns in the pivot table should \n' +
+          '    be expanded by default.\n' +
+          '  expansionDepth: A number that specifies how \n' +
+          '    many levels deep the pivot table should expand\n' +
+          '    initially. The default value is 0 - only the \n' +
+          '    first level is expanded. Larger numbers expand\n' +
+          '    more levels.\n' +
           '  columns: An array of data key strings used to\n' +
           '    specify the columns to be included and their\n' +
           '    order. If not provided, all columns from the\n' +
@@ -193,6 +201,24 @@ export const PivotTable = {
       splitBy: ['category', 'subCategory'],
       aggregates: { sales: 'any', profit: 'any' },
       columns: ['sales', 'profit'],
+    },
+    headers: tableHeaders,
+    title: 'Superstore Table',
+    description:
+      "This table displays data for sales and profit under each category. It's also grouped based on regions and states, making it useful for comparison purposes.",
+  },
+  decorators,
+}
+
+export const ExpandedTable = {
+  args: {
+    data: generateFakeData(100),
+    config: {
+      groupBy: ['region', 'state'],
+      splitBy: ['category', 'subCategory'],
+      aggregates: { sales: 'any', profit: 'any' },
+      columns: ['sales', 'profit'],
+      expandAll: true,
     },
     headers: tableHeaders,
     title: 'Superstore Table',

--- a/src/components/visualization/perspectiveViz/perspectiveViz.stories.tsx
+++ b/src/components/visualization/perspectiveViz/perspectiveViz.stories.tsx
@@ -38,14 +38,10 @@ meta.argTypes = {
         summary: 'TableConfig.',
         detail:
           'TableConfig has the following optional fields:\n' +
-          '  expandAll: A boolean that determines whether \n' +
-          '    all rows and columns in the pivot table should \n' +
-          '    be expanded by default.\n' +
           '  expansionDepth: A number that specifies how \n' +
           '    many levels deep the pivot table should expand\n' +
-          '    initially. The default value is 0 - only the \n' +
-          '    first level is expanded. Larger numbers expand\n' +
-          '    more levels.\n' +
+          '    initially. By default, all of the rows are \n' +
+          '    expanded. Larger numbers expand more levels.\n' +
           '  columns: An array of data key strings used to\n' +
           '    specify the columns to be included and their\n' +
           '    order. If not provided, all columns from the\n' +
@@ -210,7 +206,7 @@ export const PivotTable = {
   decorators,
 }
 
-export const ExpandedTable = {
+export const ExpandOneLevel = {
   args: {
     data: generateFakeData(100),
     config: {
@@ -218,7 +214,7 @@ export const ExpandedTable = {
       splitBy: ['category', 'subCategory'],
       aggregates: { sales: 'any', profit: 'any' },
       columns: ['sales', 'profit'],
-      expandAll: true,
+      expansionDepth: 0,
     },
     headers: tableHeaders,
     title: 'Superstore Table',

--- a/src/components/visualization/perspectiveViz/perspectiveViz.tsx
+++ b/src/components/visualization/perspectiveViz/perspectiveViz.tsx
@@ -221,13 +221,12 @@ function PerspectiveViz(props: TableData) {
                   settings: false,
                 })
                 .then(() => {
-                  if (!props.config?.expandAll) {
+                  const expansionDepth = props.config?.expansionDepth
+                  if (typeof expansionDepth === 'number') {
                     viewer.getView().then((view: View) =>
-                      view
-                        .set_depth(props.config?.expansionDepth || 0)
-                        .then(() => {
-                          viewer.resize()
-                        })
+                      view.set_depth(expansionDepth).then(() => {
+                        viewer.resize()
+                      })
                     )
                   }
 

--- a/src/components/visualization/perspectiveViz/perspectiveViz.tsx
+++ b/src/components/visualization/perspectiveViz/perspectiveViz.tsx
@@ -8,7 +8,11 @@ import '@finos/perspective-viewer/dist/css/pro-dark.css'
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
 import perspective from '@finos/perspective/dist/esm/perspective.inline.js'
-import type { Client, Table } from '@finos/perspective/dist/pkg/perspective-js'
+import type {
+  Client,
+  Table,
+  View,
+} from '@finos/perspective/dist/pkg/perspective-js'
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
 import type { HTMLPerspectiveViewerElement } from '@finos/perspective-viewer/dist/esm/perspective-viewer.inline.js'
@@ -204,11 +208,12 @@ function PerspectiveViz(props: TableData) {
         return worker.table(transformTableData(props.data, props.headers))
       })
       .then((table: Table) => {
-        if (viewerRef.current) {
-          viewerRef.current
+        const viewer = viewerRef.current
+        if (viewer) {
+          viewer
             .load(table)
             .then(() => {
-              viewerRef.current
+              viewer
                 .restore({
                   ...transformedConfig,
                   theme: perspectiveTheme,
@@ -216,10 +221,20 @@ function PerspectiveViz(props: TableData) {
                   settings: false,
                 })
                 .then(() => {
-                  if (viewerRef.current.shadowRoot) {
+                  if (!props.config?.expandAll) {
+                    viewer.getView().then((view: View) =>
+                      view
+                        .set_depth(props.config?.expansionDepth || 0)
+                        .then(() => {
+                          viewer.resize()
+                        })
+                    )
+                  }
+
+                  if (viewer.shadowRoot) {
                     const sheet = new CSSStyleSheet()
                     sheet.replaceSync(perspectiveVizAdditionalStyles)
-                    viewerRef.current.shadowRoot.adoptedStyleSheets.push(sheet)
+                    viewer.shadowRoot.adoptedStyleSheets.push(sheet)
                   }
                 })
             })


### PR DESCRIPTION
## Changes
- Support configuring expansionDepth and expandAll for initial render

## Before
![Screenshot 2025-02-05 at 3 53 03 PM](https://github.com/user-attachments/assets/e234dd6b-7fef-49d5-80f0-82a831ac3b6d)

## After
![Screenshot 2025-02-05 at 4 32 32 PM](https://github.com/user-attachments/assets/c37100ff-ca0b-4e25-b6e1-0980c38601ea)

ExpansionDepth=0
![Screenshot 2025-02-05 at 3 51 50 PM](https://github.com/user-attachments/assets/cbb9c142-2ab9-4747-9e93-433fce0ece3c)

ExpansionDepth=1
![Screenshot 2025-02-05 at 12 34 25 PM](https://github.com/user-attachments/assets/bd4f7a72-7bb1-4797-9b3c-dc35c98d4f16)
ExpansionDepth=2
![Screenshot 2025-02-05 at 12 34 41 PM](https://github.com/user-attachments/assets/e122447f-969d-4948-ba21-177c7320db0a)
