### PR TITLE
fix: use markdown to display description and text content

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,8 @@
         "@mui/styled-engine-sc": "6.1.8",
         "@mui/system": "6.1.8",
         "axios": "1.8.1",
+        "dompurify": "3.2.4",
+        "marked": "15.0.7",
         "react": "18.3.1"
       },
       "devDependencies": {
@@ -69,7 +71,6 @@
         "cypress-intercept-formdata": "0.6.0",
         "cypress-real-events": "1.13.0",
         "cz-conventional-changelog": "3.3.0",
-        "dompurify": "3.2.4",
         "emoji-picker-element": "1.26.0",
         "emoji-picker-element-data": "1.7.1",
         "eslint-config-prettier": "9.1.0",
@@ -81,7 +82,6 @@
         "eslint-plugin-unused-imports": "4.1.4",
         "husky": "9.1.7",
         "lint-staged": "15.2.2",
-        "marked": "15.0.7",
         "mermaid": "11.4.1",
         "mini-css-extract-plugin": "2.8.1",
         "mock-socket": "9.3.1",
@@ -130,10 +130,8 @@
         "@types/react": "^18.2.37",
         "@types/react-dom": "^18.2.15",
         "axios": "1.8.1",
-        "dompurify": "^3.2.4",
         "emoji-picker-element": "^1.21.3",
         "emoji-picker-element-data": "^1.7.1",
-        "marked": "^15.0.7",
         "mermaid": "^11.4.1",
         "ol": "^9.0.0",
         "pdfjs-dist": "^4.3.136",
@@ -192,16 +190,10 @@
         "axios": {
           "optional": true
         },
-        "dompurify": {
-          "optional": true
-        },
         "emoji-picker-element": {
           "optional": true
         },
         "emoji-picker-element-data": {
-          "optional": true
-        },
-        "marked": {
           "optional": true
         },
         "mermaid": {
@@ -5278,7 +5270,7 @@
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
       "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@types/uuid": {
@@ -9403,7 +9395,6 @@
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.4.tgz",
       "integrity": "sha512-ysFSFEDVduQpyhzAob/kkuJjf5zWkZD8/A9ywSp1byueyuCfHamrCBa14/Oc2iiB0e51B+NpxSl5gmzn+Ms/mg==",
-      "dev": true,
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
@@ -14900,7 +14891,6 @@
       "version": "15.0.7",
       "resolved": "https://registry.npmjs.org/marked/-/marked-15.0.7.tgz",
       "integrity": "sha512-dgLIeKGLx5FwziAnsk4ONoGwHwGPJzselimvlVskE9XLN4Orv9u2VA3GWw/lYUqjfA0rUT/6fqKwfZJapP9BEg==",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "marked": "bin/marked.js"

--- a/package.json
+++ b/package.json
@@ -31,6 +31,8 @@
     "@mui/styled-engine-sc": "6.1.8",
     "@mui/system": "6.1.8",
     "axios": "1.8.1",
+    "dompurify": "3.2.4",
+    "marked": "15.0.7",
     "react": "18.3.1"
   },
   "devDependencies": {
@@ -85,7 +87,6 @@
     "cypress-intercept-formdata": "0.6.0",
     "cypress-real-events": "1.13.0",
     "cz-conventional-changelog": "3.3.0",
-    "dompurify": "3.2.4",
     "emoji-picker-element": "1.26.0",
     "emoji-picker-element-data": "1.7.1",
     "eslint-config-prettier": "9.1.0",
@@ -97,7 +98,6 @@
     "eslint-plugin-unused-imports": "4.1.4",
     "husky": "9.1.7",
     "lint-staged": "15.2.2",
-    "marked": "15.0.7",
     "mermaid": "11.4.1",
     "mini-css-extract-plugin": "2.8.1",
     "mock-socket": "9.3.1",
@@ -146,10 +146,8 @@
     "@types/react": "^18.2.37",
     "@types/react-dom": "^18.2.15",
     "axios": "1.8.1",
-    "dompurify": "^3.2.4",
     "emoji-picker-element": "^1.21.3",
     "emoji-picker-element-data": "^1.7.1",
-    "marked": "^15.0.7",
     "mermaid": "^11.4.1",
     "ol": "^9.0.0",
     "pdfjs-dist": "^4.3.136",
@@ -212,12 +210,6 @@
       "optional": true
     },
     "emoji-picker-element-data": {
-      "optional": true
-    },
-    "dompurify": {
-      "optional": true
-    },
-    "marked": {
       "optional": true
     },
     "mermaid": {

--- a/src/components/calendar/fCCalendar.tsx
+++ b/src/components/calendar/fCCalendar.tsx
@@ -5,9 +5,11 @@ import FullCalendar from '@fullcalendar/react'
 import timeGridPlugin from '@fullcalendar/timegrid'
 import Box from '@mui/material/Box'
 import { useTheme } from '@mui/material/styles'
+import Typography from '@mui/material/Typography'
 import useMediaQuery from '@mui/material/useMediaQuery'
 import React from 'react'
 
+import MarkedMarkdown from '../markdown/markedMarkdown'
 import type { CalendarData, CalendarEvent } from '../types'
 
 /** Convert CalendarEvent type to FullCalendar's Event type
@@ -79,6 +81,8 @@ export default function FCCalendar(props: CalendarData) {
         },
       }}
     >
+      {props.title && <Typography variant="h6">{props.title}</Typography>}
+      {props.description && <MarkedMarkdown text={props.description} />}
       <FullCalendar
         plugins={[timeGridPlugin, dayGridPlugin]}
         initialView={getDefaultInitialView()}

--- a/src/components/codeSnippet/codeSnippet.tsx
+++ b/src/components/codeSnippet/codeSnippet.tsx
@@ -8,6 +8,7 @@ import Typography from '@mui/material/Typography'
 import { Box } from '@mui/system'
 import React, { useEffect, useRef } from 'react'
 
+import MarkedMarkdown from '../markdown/markedMarkdown'
 import type { CodeData } from '../types'
 
 /** The `CodeSnippet` component, powered by [CodeMirror](https://codemirror.net/), enables displaying code blocks with syntax highlighting for [various programming languages](https://codemirror.net/5/mode/). For further customization of the component's theme, refer to the [styling guide](https://codemirror.net/examples/styling/) provided by the CodeMirror library.
@@ -57,11 +58,12 @@ export default function CodeSnippet(props: CodeData) {
   }, [])
 
   return (
-    <Box
-      sx={{ backgroundColor: 'background.default' }}
-      className="rustic-code-snippet"
-    >
-      <div
+    <Box>
+      {props.title && <Typography variant="h6">{props.title}</Typography>}
+      {props.description && <MarkedMarkdown text={props.description} />}
+      <Box
+        className="rustic-code-snippet"
+        sx={{ backgroundColor: 'background.default' }}
         aria-label="code snippet"
         ref={codeSnippetContainer}
         data-cy="code-block"
@@ -73,7 +75,7 @@ export default function CodeSnippet(props: CodeData) {
         >
           {props.language}
         </Typography>
-      </div>
+      </Box>
     </Box>
   )
 }

--- a/src/components/dynamicForm/uniformsForm.tsx
+++ b/src/components/dynamicForm/uniformsForm.tsx
@@ -6,6 +6,7 @@ import { JSONSchemaBridge } from 'uniforms-bridge-json-schema'
 import { AutoForm } from 'uniforms-mui'
 import { v4 as getUUID } from 'uuid'
 
+import MarkedMarkdown from '../markdown/markedMarkdown'
 import type { DynamicFormProps, Message } from '../types'
 
 /**
@@ -68,9 +69,7 @@ export default function UniformsForm(props: DynamicFormProps) {
   return (
     <Box className="rustic-form">
       {props.title && <Typography variant="h6">{props.title}</Typography>}
-      {props.description && (
-        <Typography variant="body1">{props.description}</Typography>
-      )}
+      {props.description && <MarkedMarkdown text={props.description} />}
       <AutoForm
         schema={bridge}
         onSubmit={(model) => handleSubmit(model)}

--- a/src/components/image/image.tsx
+++ b/src/components/image/image.tsx
@@ -7,6 +7,7 @@ import { useState } from 'react'
 import React from 'react'
 
 import { getSizeStyles } from '../helper'
+import MarkedMarkdown from '../markdown/markedMarkdown'
 import type { ImageFormat } from '../types'
 
 /** The `Image` component facilitates the display of images, providing loading indication and error handling capabilities. It supports customization of image dimensions and alternative text, ensuring accessibility and a seamless user experience. Supported image formats: jpeg, png, gif, svg, webp, AVIF, APNG. */
@@ -29,6 +30,7 @@ export default function Image({
   return (
     <figure>
       {isLoading && <CircularProgress data-cy="spinner" />}
+      {props.title && <Typography variant="h6">{props.title}</Typography>}
       <img
         {...getSizeStyles(props.width, props.height)}
         src={props.src}
@@ -40,7 +42,7 @@ export default function Image({
       />
       {props.description && (
         <figcaption>
-          <Typography variant="body2">{props.description}</Typography>
+          <MarkedMarkdown text={props.description} />
         </figcaption>
       )}
     </figure>

--- a/src/components/map/openLayersMap.tsx
+++ b/src/components/map/openLayersMap.tsx
@@ -3,6 +3,7 @@ import './openLayersMap.css'
 
 import Alert from '@mui/material/Alert'
 import Box from '@mui/material/Box'
+import Typography from '@mui/material/Typography'
 import TileLayer from 'ol/layer/Tile.js'
 import * as olMap from 'ol/Map.js'
 import Overlay from 'ol/Overlay.js'
@@ -13,6 +14,7 @@ import React from 'react'
 import { useEffect, useRef, useState } from 'react'
 
 import Icon from '../icon/icon'
+import MarkedMarkdown from '../markdown/markedMarkdown'
 import type { LocationFormat } from '../types'
 
 /** The `OpenLayersMap` component supports OpenStreetMap tiles where users can easily zoom in and zoom out to navigate the map effectively. The `OpenLayersMap` component uses the [OpenLayers](https://openlayers.org/en/latest/apidoc/module-ol_Map-Map.html) map library.
@@ -86,6 +88,8 @@ export default function OpenLayersMap(props: LocationFormat) {
         <Alert severity="error">{errorMessage}</Alert>
       ) : (
         <Box>
+          {props.title && <Typography variant="h6">{props.title}</Typography>}
+          {props.description && <MarkedMarkdown text={props.description} />}
           <Box data-cy="marker-container" ref={markerElement}>
             <Icon
               className="rustic-open-layers-map-marker"

--- a/src/components/markdown/markedMarkdown.css
+++ b/src/components/markdown/markedMarkdown.css
@@ -1,0 +1,4 @@
+.rustic-markdown p {
+  margin-block-start: 0;
+  margin-block-end: 0;
+}

--- a/src/components/markdown/markedMarkdown.tsx
+++ b/src/components/markdown/markedMarkdown.tsx
@@ -1,3 +1,5 @@
+import './markedMarkdown.css'
+
 import Typography from '@mui/material/Typography'
 import DOMPurify from 'dompurify'
 import { marked } from 'marked'
@@ -20,13 +22,7 @@ export function convertMarkdownToHtml(text: string): string {
  *
  * On the other hand, the `MarkedStreamingMarkdown` component is designed to handle streams of markdown-formatted text data. This component supports updates involving continuous appending of new markdown data to the existing content through the `updatedData` attribute.
  *
- * Tip: Use `MarkedMarkdown` when displaying static content or when you'd like to support content overwrite updates, and use `MarkedStreamingMarkdown` when its being updated dynamically and new content should be appended to existing content.
- *
- * Note: `marked` and `dompurify` are not bundled, so please install the following packages using npm:
- *
- * ```typescript
- * npm i marked dompurify
- * ``` */
+ * Tip: Use `MarkedMarkdown` when displaying static content or when you'd like to support content overwrite updates, and use `MarkedStreamingMarkdown` when its being updated dynamically and new content should be appended to existing content.*/
 const MarkedMarkdown = (props: TextData) => {
   const [html, setHtml] = useState(convertMarkdownToHtml(props.text))
 
@@ -39,7 +35,11 @@ const MarkedMarkdown = (props: TextData) => {
   }, [props.text, props.updatedData])
 
   return (
-    <Typography variant="body2" dangerouslySetInnerHTML={{ __html: html }} />
+    <Typography
+      variant="body1"
+      className="rustic-markdown"
+      dangerouslySetInnerHTML={{ __html: html }}
+    />
   )
 }
 

--- a/src/components/media/audio/sound.tsx
+++ b/src/components/media/audio/sound.tsx
@@ -7,6 +7,7 @@ import Typography from '@mui/material/Typography'
 import { Box } from '@mui/system'
 import React, { useEffect, useRef, useState } from 'react'
 
+import MarkedMarkdown from '../../markdown/markedMarkdown'
 import type { AudioFormat } from '../../types'
 import {
   MoveTenSecondsButton,
@@ -134,7 +135,7 @@ export default function Sound(props: AudioFormat) {
           />
           <ProgressSlider mediaElement={audioRef.current} />
           {renderTitle()}
-
+          {props.description && <MarkedMarkdown text={props.description} />}
           <Box className="rustic-sound-bottom-controls">
             <Box className="rustic-sound-bottom-controls-left">
               {renderTimeControls()}
@@ -163,6 +164,7 @@ export default function Sound(props: AudioFormat) {
       return (
         <>
           {renderTitle()}
+          {props.description && <MarkedMarkdown text={props.description} />}
 
           <Box className="rustic-sound-controls">
             <ProgressSlider mediaElement={audioRef.current} />

--- a/src/components/media/video/video.tsx
+++ b/src/components/media/video/video.tsx
@@ -7,6 +7,7 @@ import Typography from '@mui/material/Typography'
 import { Box } from '@mui/system'
 import React, { useEffect, useRef, useState } from 'react'
 
+import MarkedMarkdown from '../../markdown/markedMarkdown'
 import type { VideoFormat } from '../../types'
 import {
   MoveTenSecondsButton,
@@ -304,7 +305,6 @@ export default function Video(props: VideoFormat) {
           className="rustic-video-loading-spinner"
         />
       )}
-
       <Box
         ref={videoContainerRef}
         className="rustic-video-screen"
@@ -329,6 +329,7 @@ export default function Video(props: VideoFormat) {
         {renderControls()}
       </Box>
       {!isFullscreen && renderTranscript()}
+      {props.description && <MarkedMarkdown text={props.description} />}
     </Box>
   )
 }

--- a/src/components/multipart/chatCompletion/chatCompletion.tsx
+++ b/src/components/multipart/chatCompletion/chatCompletion.tsx
@@ -4,11 +4,12 @@ import '../multipart/multipart.css'
 import Box from '@mui/material/Box'
 import IconButton from '@mui/material/IconButton'
 import Tooltip from '@mui/material/Tooltip'
+import Typography from '@mui/material/Typography'
 import React from 'react'
 
 import FilePreview from '../../filePreview/filePreview'
 import Icon from '../../icon'
-import Text from '../../text'
+import MarkedMarkdown from '../../markdown'
 import type { ChatCompletionProps, Content } from '../../types'
 
 function getFileName(fileUrl: string): string {
@@ -64,7 +65,7 @@ export default function ChatCompletion(props: ChatCompletionProps) {
     })
     return (
       <React.Fragment key={index}>
-        {textContent.length > 0 && <Text text={textContent} />}
+        {textContent.length > 0 && <MarkedMarkdown text={textContent} />}
         {files.length > 0 && <Box className="rustic-files">{files}</Box>}
       </React.Fragment>
     )
@@ -72,9 +73,15 @@ export default function ChatCompletion(props: ChatCompletionProps) {
 
   return (
     <Box className="rustic-multipart">
+      {(props.title || props.description) && (
+        <div>
+          {props.title && <Typography variant="h6">{props.title}</Typography>}
+          {props.description && <MarkedMarkdown text={props.description} />}
+        </div>
+      )}
       {props.messages.map((msg, index) => {
         if (typeof msg.content === 'string') {
-          return <Text text={msg.content} key={index} />
+          return <MarkedMarkdown text={msg.content} key={index} />
         } else {
           return renderContentArray(msg.content, index)
         }

--- a/src/components/multipart/multipart/multipart.tsx
+++ b/src/components/multipart/multipart/multipart.tsx
@@ -3,12 +3,13 @@ import './multipart.css'
 
 import IconButton from '@mui/material/IconButton'
 import Tooltip from '@mui/material/Tooltip'
+import Typography from '@mui/material/Typography'
 import Box from '@mui/system/Box'
 import React from 'react'
 
 import FilePreview from '../../filePreview/filePreview'
 import Icon from '../../icon/icon'
-import Text from '../../text/text'
+import MarkedMarkdown from '../../markdown'
 import type { MultipartProps } from '../../types'
 
 /** The `Multipart` component is a versatile message format designed to accommodate both textual content and file attachments within a single message interface. */
@@ -38,7 +39,13 @@ export default function Multipart(props: MultipartProps) {
 
   return (
     <Box className="rustic-multipart">
-      {props.text && <Text text={props.text} />}
+      {(props.title || props.description) && (
+        <div>
+          {props.title && <Typography variant="h6">{props.title}</Typography>}
+          {props.description && <MarkedMarkdown text={props.description} />}
+        </div>
+      )}
+      {props.text && <MarkedMarkdown text={props.text} />}
       {renderFiles()}
     </Box>
   )

--- a/src/components/question/question.tsx
+++ b/src/components/question/question.tsx
@@ -9,6 +9,7 @@ import React, { useState } from 'react'
 import { v4 as getUUID } from 'uuid'
 
 import { toChatRequest } from '../helper'
+import MarkedMarkdown from '../markdown/markedMarkdown'
 import type { Message, QuestionProps } from '../types'
 
 /**
@@ -72,14 +73,12 @@ export default function Question(props: QuestionProps) {
       {(props.title || props.description) && (
         <Box className="rustic-question-text">
           {props.title && (
-            <Typography variant="subtitle2" className="rustic-title">
+            <Typography variant="h6" className="rustic-title">
               {props.title}
             </Typography>
           )}
 
-          {props.description && (
-            <Typography variant="caption">{props.description}</Typography>
-          )}
+          {props.description && <MarkedMarkdown text={props.description} />}
         </Box>
       )}
 

--- a/src/components/table/table.cy.tsx
+++ b/src/components/table/table.cy.tsx
@@ -108,10 +108,7 @@ describe('Table', () => {
     it(`renders description if provided on ${viewport} screen`, () => {
       cy.viewport(viewport)
       cy.mount(<Table description="Test Description" data={testData} />)
-      cy.get('[data-cy="table-description"]').should(
-        'contain',
-        'Test Description'
-      )
+      cy.get('p').should('contain', 'Test Description')
     })
 
     it(`renders headers based on data keys if headers props are not provided on ${viewport} screen`, () => {

--- a/src/components/table/table.tsx
+++ b/src/components/table/table.tsx
@@ -16,6 +16,7 @@ import React, { useState } from 'react'
 
 import { capitalizeFirstLetter } from '../helper'
 import Icon from '../icon/icon'
+import MarkedMarkdown from '../markdown/markedMarkdown'
 import type { TableData, TableHeader } from '../types'
 
 const paginationThreshold = 10
@@ -136,9 +137,7 @@ export default function Table(props: TableData) {
         </Typography>
       )}
       {props.description && (
-        <Typography variant="body1" data-cy="table-description">
-          {props.description}
-        </Typography>
+        <MarkedMarkdown text={props.description} data-cy="table-description" />
       )}
       <TableContainer className="rustic-table-container">
         <MuiTable

--- a/src/components/text/text.tsx
+++ b/src/components/text/text.tsx
@@ -20,7 +20,7 @@ import type { TextData } from '../types'
  * ``` */
 const Text = (props: TextData) => {
   return (
-    <Typography variant="body2" className="rustic-text">
+    <Typography variant="body1" className="rustic-text">
       {DOMPurify.sanitize(props.text)}
     </Typography>
   )

--- a/src/components/visualization/chart/rechartsTimeSeries.tsx
+++ b/src/components/visualization/chart/rechartsTimeSeries.tsx
@@ -26,6 +26,7 @@ import {
 
 import { calculateTimeDiffInDays, formatTimestampLabel } from '../../helper'
 import Icon from '../../icon/icon'
+import MarkedMarkdown from '../../markdown/markedMarkdown'
 
 export interface TimeSeriesData {
   timestamp: number
@@ -113,7 +114,7 @@ const defaultYAxisLabelWidth = 30
  *
  * Note: `Recharts` is not bundled, so please install the following package using npm:
  *
- * ```typescript
+ * ```
  * npm i recharts
  * ```
  */
@@ -359,7 +360,7 @@ function RechartsTimeSeries({
         <Box>
           {props.title && (
             <Typography
-              variant="subtitle2"
+              variant="h6"
               className="rustic-recharts-time-series-title"
               data-cy="time-series-title"
             >
@@ -367,14 +368,7 @@ function RechartsTimeSeries({
             </Typography>
           )}
 
-          {props.description && (
-            <Typography
-              variant="caption"
-              className="rustic-recharts-time-series-description"
-            >
-              {props.description}
-            </Typography>
-          )}
+          {props.description && <MarkedMarkdown text={props.description} />}
 
           <ResponsiveContainer
             aspect={aspectRatio}

--- a/src/components/visualization/mermaidViz/mermaidViz.tsx
+++ b/src/components/visualization/mermaidViz/mermaidViz.tsx
@@ -8,6 +8,7 @@ import mermaid from 'mermaid'
 import React, { useEffect, useRef, useState } from 'react'
 import { v4 as getUUID } from 'uuid'
 
+import MarkedMarkdown from '../../markdown/markedMarkdown'
 import type { MermaidData } from './mermaidViz.types'
 
 /** The `MermaidViz` component leverages [Mermaid.js](https://mermaid.js.org/) to create dynamic and interactive diagrams, including flowcharts, sequence diagrams, class diagrams, and more. It is ideal for visualizing complex data and processes in a clear and structured manner.
@@ -52,12 +53,8 @@ function MermaidViz(props: MermaidData) {
 
   return (
     <Stack className={`rustic-mermaid-container`} data-cy="mermaid-container">
-      {props.title && (
-        <Typography variant="subtitle2">{props.title}</Typography>
-      )}
-      {props.description && (
-        <Typography variant="caption">{props.description}</Typography>
-      )}
+      {props.title && <Typography variant="h6">{props.title}</Typography>}
+      {props.description && <MarkedMarkdown text={props.description} />}
       <div className="rustic-mermaid" ref={mermaidRef}></div>
       {errorMessage && <Typography variant="body2">{errorMessage}</Typography>}
     </Stack>

--- a/src/components/visualization/perspectiveViz/perspectiveViz.cy.tsx
+++ b/src/components/visualization/perspectiveViz/perspectiveViz.cy.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable no-magic-numbers */
 import PerspectiveViz from './perspectiveViz'
 const sampleData = [
   {
@@ -46,7 +45,7 @@ describe('PerspectiveViz Component', () => {
     cy.mount(<PerspectiveViz {...data} />)
 
     cy.get('[data-cy=table-title]').should('contain', 'Superstore Sales Data')
-    cy.get('[data-cy=table-description]').should(
+    cy.get('p').should(
       'contain',
       'This table displays sales and profit data grouped by region and state, and split by category.'
     )

--- a/src/components/visualization/perspectiveViz/perspectiveViz.tsx
+++ b/src/components/visualization/perspectiveViz/perspectiveViz.tsx
@@ -21,6 +21,7 @@ import Typography from '@mui/material/Typography'
 import Stack from '@mui/system/Stack'
 import React, { useEffect, useRef, useState } from 'react'
 
+import MarkedMarkdown from '../../markdown/markedMarkdown'
 import type {
   TableConfig,
   TableData,
@@ -257,9 +258,10 @@ function PerspectiveViz(props: TableData) {
           </Typography>
         )}
         {props.description && (
-          <Typography variant="body1" data-cy="table-description">
-            {props.description}
-          </Typography>
+          <MarkedMarkdown
+            text={props.description}
+            data-cy="table-description"
+          />
         )}
         <perspective-viewer
           ref={viewerRef}

--- a/src/components/visualization/plotlyGraph/plotlyGraph.tsx
+++ b/src/components/visualization/plotlyGraph/plotlyGraph.tsx
@@ -1,8 +1,10 @@
-import React from 'react';
+import Typography from '@mui/material/Typography'
+import Box from '@mui/system/Box'
+import React from 'react'
 import Plot from 'react-plotly.js'
-import type {PlotlyGraphData} from "./plotlyGraph.types";
-import Typography from "@mui/material/Typography";
-import Box from "@mui/system/Box";
+
+import MarkedMarkdown from '../../markdown/markedMarkdown'
+import type { PlotlyGraphData } from './plotlyGraph.types'
 /** The `PlotlyGraph` component enables interactive charts and maps using [Plotly](https://plotly.com/javascript/),
  *  offering rich features such as zooming, panning, and downloading graphs. It supports customization of graph
  *  parameters and configurations to suit various visualization needs.
@@ -14,25 +16,22 @@ import Box from "@mui/system/Box";
  * ```
  */
 function PlotlyGraph(props: PlotlyGraphData) {
+  const additionalConfig = {
+    displaylogo: false,
+    responsive: true,
+    editable: false,
+  }
 
-    const additionalConfig = {
-        displaylogo: false,
-        responsive: true,
-        editable: false,
-    }
+  const plotParams = { ...props.plotParams, className: 'rustic-plotly' }
+  plotParams.config = { ...plotParams.config, ...additionalConfig }
 
-    const plotParams = {...props.plotParams, className: 'rustic-plotly'}
-    plotParams.config = {...plotParams.config, ...additionalConfig}
-
-    return (
-        <Box className={'rustic-plotly-container'} data-cy="plotly">
-            {props.title && <Typography variant="h6">{props.title}</Typography>}
-            {props.description && (
-                <Typography variant="body1">{props.description}</Typography>
-            )}
-            <Plot {...plotParams}></Plot>
-        </Box>
-    )
+  return (
+    <Box className={'rustic-plotly-container'} data-cy="plotly">
+      {props.title && <Typography variant="h6">{props.title}</Typography>}
+      {props.description && <MarkedMarkdown text={props.description} />}
+      <Plot {...plotParams}></Plot>
+    </Box>
+  )
 }
 
 export default PlotlyGraph

--- a/src/components/visualization/vegaLiteViz/vegaLiteViz.tsx
+++ b/src/components/visualization/vegaLiteViz/vegaLiteViz.tsx
@@ -15,10 +15,10 @@ import type { VegaLiteData } from './vegaLiteViz.types'
 
 /** The `VegaLiteViz` component is a versatile tool for visualizing data using the Vega-Lite grammar. With support for various graphic types, it empowers users to create engaging and informative data visualizations effortlessly.
  *
- * Note: `vega-embed`, `marked` and `dompurify` are not bundled, so please install the following packages using npm:
+ * Note: `vega-embed` is not bundled, so please install the following package using npm:
  *
  * ```typescript
- * npm i vega-embed marked dompurify
+ * npm i vega-embed
  * ```
  */
 function VegaLiteViz({

--- a/src/components/weather/weather.tsx
+++ b/src/components/weather/weather.tsx
@@ -8,6 +8,7 @@ import React, { useState } from 'react'
 
 import { getDayFromUnixTime } from '../helper'
 import Icon from '../icon/icon'
+import MarkedMarkdown from '../markdown/markedMarkdown'
 import PopoverMenu from '../menu/popoverMenu'
 import type { WeatherProps } from '../types'
 
@@ -91,6 +92,8 @@ export default function Weather(props: WeatherProps) {
 
   return (
     <Card variant="outlined" className="rustic-weather">
+      {props.title && <Typography variant="h6">{props.title}</Typography>}
+      {props.description && <MarkedMarkdown text={props.description} />}
       <PopoverMenu
         ariaLabel="Temperature units"
         menuItems={[


### PR DESCRIPTION
## Changes
- Use markdown to display description and text content
- Add title and description to all message formats
- Use body1(16px) for text content/description

## Screenshots
<img width="855" alt="Screenshot 2025-03-13 at 5 15 58 PM" src="https://github.com/user-attachments/assets/37b64cf1-2fb0-43ff-8ea6-cf209e4d2246" />
<img width="944" alt="Screenshot 2025-03-13 at 5 17 08 PM" src="https://github.com/user-attachments/assets/65264184-8481-456b-b134-aab87455df7e" />

<img width="839" alt="Screenshot 2025-03-13 at 5 23 55 PM" src="https://github.com/user-attachments/assets/2fdf743d-1919-4eaf-ba24-f90c9a98e4fa" />
