### PR TITLE
fix: add getAuthHeaders to file-related components

### DIFF
--- a/src/components/filePreview/filePreview.tsx
+++ b/src/components/filePreview/filePreview.tsx
@@ -12,16 +12,24 @@ import React, { useState } from 'react'
 import { shortenString } from '../helper'
 import Icon from '../icon/icon'
 import PDFViewer from '../pdfViewer/pdfViewer'
-import type { FileData } from '../types'
+import type { FileData, GetAuthHeaders } from '../types'
+
+type ViewerComponent = React.ComponentType<{
+  url: string
+  getAuthHeaders?: GetAuthHeaders
+}>
 
 export interface FilePreviewProps {
   file: FileData
-  supportedViewers?: { [key: string]: React.ComponentType<{ url: string }> }
+  supportedViewers?: {
+    [key: string]: ViewerComponent
+  }
   showFullName?: boolean
+  getAuthHeaders?: GetAuthHeaders
 }
 
 const defaultSupportedViewers: {
-  [key: string]: React.ComponentType<{ url: string }>
+  [key: string]: ViewerComponent
 } = {
   pdf: PDFViewer,
   // Add more mappings as needed for different file types
@@ -65,6 +73,7 @@ export default function FilePreview({
   const fileName = showFullName
     ? props.file.name
     : shortenString(props.file.name, maximumFileNameLength)
+
   return (
     <>
       <Card
@@ -100,7 +109,12 @@ export default function FilePreview({
                 <Icon name="close" />
               </IconButton>
             </Tooltip>
-            {props.file.url && <ModalContentComponent url={props.file.url} />}
+            {props.file.url && (
+              <ModalContentComponent
+                url={props.file.url}
+                getAuthHeaders={props.getAuthHeaders}
+              />
+            )}
           </div>
         </Modal>
       )}

--- a/src/components/multipart/chatCompletion/chatCompletion.stories.tsx
+++ b/src/components/multipart/chatCompletion/chatCompletion.stories.tsx
@@ -37,6 +37,12 @@ export default meta
 
 export const Default = {
   args: {
+    getAuthHeaders: () =>
+      Promise.resolve({
+        headers: {
+          Authorization: 'Bearer example-token',
+        },
+      }),
     messages: [
       {
         content: [

--- a/src/components/multipart/chatCompletion/chatCompletion.tsx
+++ b/src/components/multipart/chatCompletion/chatCompletion.tsx
@@ -44,7 +44,11 @@ export default function ChatCompletion(props: ChatCompletionProps) {
         }
 
         const preview = (
-          <FilePreview file={file} showFullName={props.showFullName}>
+          <FilePreview
+            file={file}
+            showFullName={props.showFullName}
+            getAuthHeaders={props.getAuthHeaders}
+          >
             {file.url && (
               <Tooltip title="Download" className="rustic-shift-to-right-by-8">
                 <IconButton

--- a/src/components/multipart/multipart/multipart.stories.tsx
+++ b/src/components/multipart/multipart/multipart.stories.tsx
@@ -53,6 +53,12 @@ export const FileWithURL = {
         url: 'files/pdfExample.pdf',
       },
     ],
+    getAuthHeaders: () =>
+      Promise.resolve({
+        headers: {
+          Authorization: 'Bearer example-token',
+        },
+      }),
   },
 }
 

--- a/src/components/multipart/multipart/multipart.tsx
+++ b/src/components/multipart/multipart/multipart.tsx
@@ -16,7 +16,12 @@ export default function Multipart(props: MultipartProps) {
   function renderFiles() {
     const files = props.files.map((file, index) => {
       return (
-        <FilePreview file={file} showFullName={props.showFullName} key={index}>
+        <FilePreview
+          file={file}
+          showFullName={props.showFullName}
+          getAuthHeaders={props.getAuthHeaders}
+          key={index}
+        >
           {file.url && (
             <Tooltip title="Download" className="rustic-shift-to-right-by-8">
               <IconButton

--- a/src/components/pdfViewer/pdfViewer.stories.tsx
+++ b/src/components/pdfViewer/pdfViewer.stories.tsx
@@ -1,7 +1,7 @@
 import type { StoryFn } from '@storybook/react'
 import React from 'react'
 
-import PDFViewer, {setPdfWorkerSrc} from './pdfViewer'
+import PDFViewer, { setPdfWorkerSrc } from './pdfViewer'
 
 setPdfWorkerSrc('files/pdf.worker.mjs')
 
@@ -16,6 +16,12 @@ export default {
 
 export const Default = {
   args: {
+    getAuthHeader: () =>
+      Promise.resolve({
+        headers: {
+          Authorization: 'Bearer example-token',
+        },
+      }),
     url: 'files/pdfExample.pdf',
   },
   decorators: [

--- a/src/components/pdfViewer/pdfViewer.tsx
+++ b/src/components/pdfViewer/pdfViewer.tsx
@@ -117,13 +117,12 @@ function PDFViewer(props: PDFViewerProps) {
     })
   }
 
-  useEffect(() => {
-    if (!pdfjsLib.GlobalWorkerOptions.workerSrc) {
-      // Use a fallback if not configured
-      pdfjsLib.GlobalWorkerOptions.workerSrc = `https://cdnjs.cloudflare.com/ajax/libs/pdf.js/${pdfjsLib.version}/pdf.worker.mjs`
-    }
+  function loadPdf(headers?: Record<string, string>) {
     pdfjsLib
-      .getDocument({ url: `${props.url}` })
+      .getDocument({
+        url: props.url,
+        httpHeaders: headers,
+      })
       .promise.then((pdf) => {
         setTotalPages(pdf.numPages)
         renderPage(pdf)
@@ -131,6 +130,22 @@ function PDFViewer(props: PDFViewerProps) {
       .catch(() => {
         setHasError(true)
       })
+  }
+
+  useEffect(() => {
+    if (!pdfjsLib.GlobalWorkerOptions.workerSrc) {
+      // Use a fallback if not configured
+      pdfjsLib.GlobalWorkerOptions.workerSrc = `https://cdnjs.cloudflare.com/ajax/libs/pdf.js/${pdfjsLib.version}/pdf.worker.mjs`
+    }
+
+    if (props.getAuthHeaders) {
+      props
+        .getAuthHeaders()
+        .then((auth) => loadPdf(auth.headers))
+        .catch(() => setHasError(true))
+    } else {
+      loadPdf()
+    }
   }, [props.url, currentPage, scale])
 
   function goToPreviousPage() {

--- a/src/components/types.ts
+++ b/src/components/types.ts
@@ -208,6 +208,12 @@ export interface VideoFormat extends MediaFormat {
   poster?: string
 }
 
+export type GetAuthHeaders = () => Promise<{
+  headers: {
+    Authorization: string
+  }
+}>
+
 export interface FileData {
   name: string
   url?: string
@@ -232,6 +238,8 @@ export interface MultipartProps extends MultipartData {
   supportedViewers?: { [key: string]: React.ComponentType<{ url: string }> }
   /** Setting this to true will display long file names in full. If set to false, long names will be shortened. */
   showFullName?: boolean
+  /** A function that can be used to get the headers for the file requests. */
+  getAuthHeaders?: GetAuthHeaders
 }
 
 export enum ParticipantRole {
@@ -322,11 +330,7 @@ export interface UploaderProps {
   /** A function that can be used to define additional data to be sent along with the file upload. */
   getUploadData?: (fileName: string) => { [key: string]: any }
   /** A function that can be used to get the headers for the file upload requests. */
-  getUploadHeaders?: () => Promise<{
-    headers: {
-      Authorization: string
-    }
-  }>
+  getUploadHeaders?: GetAuthHeaders
   /** Defines the available options for file upload, displayed within a popover menu. If no options are provided, an upload icon button will be displayed by default.*/
   uploadOptions?: UploadOption[]
   /** A function to fetch and format existing file data when a file upload fails due to a conflict error (HTTP status code 409). The returned value will be used to determine a unique file name by appending an incremented number to the base name.  */
@@ -374,6 +378,8 @@ export interface PromptsProps extends PromptsFormat, ConversationProps {
 export interface PDFViewerProps {
   /** The url of the PDF file to be displayed. */
   url: string
+  /** A function that can be used to get the headers for the pdf requests. */
+  getAuthHeaders?: GetAuthHeaders
 }
 
 export interface Weather {
@@ -480,4 +486,6 @@ export interface ChatCompletionProps extends DataFormat, ChatCompletionRequest {
   supportedViewers?: { [key: string]: React.ComponentType<{ url: string }> }
   /** Setting this to true will display long file names in full. If set to false, long names will be shortened. */
   showFullName?: boolean
+  /** A function that can be used to get the headers for the file requests. */
+  getAuthHeaders?: GetAuthHeaders
 }


### PR DESCRIPTION
## Changes
- add getAuthHeaders to file-related components (PDFViewer, ChatCompletion, Multipart)

## Screenshots
<img width="462" alt="Screenshot 2025-03-14 at 2 18 16 PM" src="https://github.com/user-attachments/assets/d5ae7b0c-07db-446a-ac97-6d3bfc943f3c" />
<img width="717" alt="Screenshot 2025-03-14 at 2 20 07 PM" src="https://github.com/user-attachments/assets/9414432a-e431-46da-9c0a-41e2a64a5998" />
