### PR TITLE
chore: bump the version for release

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@rustic-ai/ui-components",
-  "version": "0.0.38",
+  "version": "0.0.39",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@rustic-ai/ui-components",
-      "version": "0.0.38",
+      "version": "0.0.39",
       "license": "MIT",
       "dependencies": {
         "@emotion/react": "11.11.1",
@@ -129,6 +129,7 @@
         "@mui/system": "^6.1.8",
         "@types/react": "^18.2.37",
         "@types/react-dom": "^18.2.15",
+        "axios": "1.8.2",
         "emoji-picker-element": "^1.21.3",
         "emoji-picker-element-data": "^1.7.1",
         "mermaid": "^11.4.1",
@@ -184,6 +185,9 @@
           "optional": true
         },
         "@fullcalendar/timegrid": {
+          "optional": true
+        },
+        "axios": {
           "optional": true
         },
         "emoji-picker-element": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rustic-ai/ui-components",
-  "version": "0.0.38",
+  "version": "0.0.39",
   "keywords": [
     "rustic-ai",
     "conversational-ui"

--- a/src/components/video/youtubeVideo.tsx
+++ b/src/components/video/youtubeVideo.tsx
@@ -16,7 +16,9 @@ export interface YoutubeVideoProps {
   title?: string
 }
 
-/** The `YoutubeVideo` component enables the embedding of YouTube videos, providing a seamless playback experience.
+/** > **Deprecated:** Use `Video` component instead. This component will be removed in the next release.
+ *
+ * The `YoutubeVideo` component enables the embedding of YouTube videos, providing a seamless playback experience.
  *
  * Note: `dompurify` is not bundled, so please install the following package using npm:
  *

--- a/src/components/visualization/chart/rechartsTimeSeries.tsx
+++ b/src/components/visualization/chart/rechartsTimeSeries.tsx
@@ -110,7 +110,9 @@ function areAllDatasetsVisible(datasetsVisibility: { [key: string]: boolean }) {
 const defaultMinChartWidth = 200
 const defaultMaxHeight = 600
 const defaultYAxisLabelWidth = 30
-/** The `RechartsTimeSeries` component integrates the [Recharts](https://recharts.org/en-US/api) library to facilitate the visualization of time-based data through various chart types such as line charts, bar charts, and area charts. It supports customizations for reference lines, tooltips, and chart type toggling, providing a flexible and interactive data representation solution.
+/** > **Deprecated:** Use other visualization components instead. This component will be removed in the next release.
+ *
+ * The `RechartsTimeSeries` component integrates the [Recharts](https://recharts.org/en-US/api) library to facilitate the visualization of time-based data through various chart types such as line charts, bar charts, and area charts. It supports customizations for reference lines, tooltips, and chart type toggling, providing a flexible and interactive data representation solution.
  *
  * Note: `Recharts` is not bundled, so please install the following package using npm:
  *


### PR DESCRIPTION
## Changes
- Bump the version for release
- Mention Youtube Video and Recharts Time Series Components will be deprecated

## Screenshots
<img width="736" alt="Screenshot 2025-03-18 at 9 33 27 AM" src="https://github.com/user-attachments/assets/366ebfc7-5460-44c5-af7b-9fdfb95c3824" />
<img width="811" alt="Screenshot 2025-03-18 at 9 33 51 AM" src="https://github.com/user-attachments/assets/13e3330e-ebbb-4cb0-a72b-7ca92289e837" />
